### PR TITLE
Refactor formtool grid configs

### DIFF
--- a/lib/formtools/plugin.js
+++ b/lib/formtools/plugin.js
@@ -88,7 +88,7 @@ var columnsDefaults = function (columns) {
 
         }
 
-        if (column === 'title' && !columns[column].renderer) {
+        if ((column === 'title' || column === 'label') && !columns[column].renderer) {
 
             columns[column].renderer = linz.formtools.cellRenderers.overviewLink;
 

--- a/lib/formtools/renderers-cell.js
+++ b/lib/formtools/renderers-cell.js
@@ -2,7 +2,7 @@ var moment = require('moment'),
     linz = require('../../');
 
 var dateRenderer = module.exports.date = function dateRenderer(date, record, fieldName, model, callback) {
-    return callback(null, moment(date).format('dd DD/MM/YYYY'));
+    return callback(null, moment(date).format('ddd DD/MM/YYYY'));
 };
 
 var linkRenderer = module.exports.overviewLink = function overviewLinkRenderer(val, record, fieldName, model, callback) {


### PR DESCRIPTION
This PR will be used to refactor form tools, in relation to grid configuration. Updates to include:
- [x] making cell renderers asynchronous
- [ ] adding paging
- [x] virtual columns
- [x] default title column to use the `overviewLink` renderer
- [x] add row numbering
- [x] add row checkboxes (for group actions)
- [x] dataset filtering (MMS-71)

This initial commit provides asynchronous cell renderers, and removes logic from the view, adding it to the modelIndex middleware instead (updating record field values, with their cell-rendered counterparts).
### Virtual columns

This will allow a column to be produced, that isn't based on a model's field. A renderer for a column virtual must be supplied, and virtual columns would also need to be identified.

``` js
grid: {
    columns: {
        title: {
            label: 'Label',
            renderer: linz.formtools.cellRenderers.overviewLink
        },
        alias: 'Alias',
        dateModified: 'Modified',
        count: {
            label: 'View count',
            renderer: rendererFunctionName,
            virtual: true
        }
    }
}
```

A virtual column renderer will need a signature matching:

``` js
rendererFn(record, model)
```
