### PR TITLE
Referenced documents

### DIFF
--- a/lib/formtools/form.js
+++ b/lib/formtools/form.js
@@ -65,32 +65,31 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, r, form
         }
 
         async.series([
-            // TODO: need to refactor this!!
-            // function (callback) {
+            function (callback) {
 
-            //     // if the field has a reference, we need to grab the values for that type and add them in
-            //     if (field.options.ref) {
+                // if the field has a reference, we need to grab the values for that type and add them in
+                if (m.schema.tree[fieldName].ref) {
 
-            //         mongoose.models[field.options.ref].find({}, function (err, docs) {
+                    linz.mongoose.models[m.schema.tree[fieldName].ref].find({}, function (err, docs) {
 
-            //             field.type = 'enum';
-            //             choices = {};
+                        field.type = 'enum';
+                        choices = {};
 
-            //             docs.forEach(function (doc) {
-            //                 choices[doc._id.toString()] = doc.title || doc.label || doc.name || doc.toString();
-            //             });
+                        docs.forEach(function (doc) {
+                            choices[doc._id.toString()] = doc.title || doc.label || doc.name || doc.toString();
+                        });
 
-            //             callback(null);
+                        callback(null);
 
-            //         });
+                    });
 
-            //     } else {
+                } else {
 
-            //         callback(null);
+                    callback(null);
 
-            //     }
+                }
 
-            // },
+            },
             function (callback) {
 
                 if (field.visible === false || (formType === 'create' && !field.create.visible) || (formType === 'edit' && !field.edit.visible) )

--- a/middleware/modelSave.js
+++ b/middleware/modelSave.js
@@ -5,7 +5,13 @@ module.exports = function () {
 	return function (req, res, next) {
 
 		req.linz.model = req.linz.get('models')[req.params.model];
-        next();
+
+        req.linz.model.getForm(function(err,form){
+
+            req.linz.model.form = form;
+            next();
+
+        });
 
 	}
 


### PR DESCRIPTION
This reinstates the ability to use referenced types within a model, and provide them as options on the create/edit form handlers.

To define a referenced type within mongoose, use:

``` js
category: {
    type: linz.mongoose.Schema.Types.ObjectId,
    ref: 'category'
}
```
