### PR TITLE
Need ability to define custom verify password function for user login

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -12,9 +12,6 @@ var defaults = module.exports = {
 	// user model and authentication
 	'username key': 'username',
 	'password key': 'password',
-	'verify password': function (first, second) {
-		return (first === second);
-	},
 
 	// error logging and output
 	'error log': console.log

--- a/lib/helpers-passport.js
+++ b/lib/helpers-passport.js
@@ -23,40 +23,32 @@ exports.login = new LocalStrategy('linz-local', function (username, password, do
 		}
 
         // check if a verifyPassword function is defined for user model
-        if (user.verifyPassword){
+        if (!user.verifyPassword){
 
-            user.verifyPassword(password, function(err, isMatch) {
+            debugSession('Verified credentials for ' + username);
+            return done(new Error('A verifyPassword method was not defined in the user model ' + linz.get('user model')), false);
 
-              if (err) return done(err);
+        }
 
-              if(isMatch) {
+        user.verifyPassword(password, function(err, isMatch) {
+
+            if (err) {
+                return done(err);
+            }
+
+            if(isMatch) {
 
                 debugSession('Verified credentials for ' + username);
                 return done(null, user);
 
-              } else {
+            } else {
 
                 debugSession('Password did not match for user ' + username);
                 return done(null, false, { message: 'Invalid password' });
 
-              }
+            }
 
-            });
-
-        } else if (!linz.get('verify password')(password, user[linz.get('password key')])) {
-
-            /**
-             * To manipulate how a session is modified, create a function called 'verify password'
-             * on the Linz configuration object, and it will be executed with the form password and database password
-             */
-
-			debugSession('Password did not match for user ' + username);
-			return done(null, false);
-
-		}
-
-		debugSession('Verified credentials for ' + username);
-		return done(null, user);
+        });
 
 	});
 


### PR DESCRIPTION
We need to add encryption on user password. Currently Linz only allow ability to override the default  'verify password' function via using Linz.set() function, which I've tried and it is **not** working. Linz did correctly set('verify password'), however the helpers-password is still loading the default verify password function.

I think it would be much cleaner to give user ability to define custom verify password function in the user model as shown in the first commit of this PR below (line 25 - 46).

If custom verify password function is not define if should either use the default one.
