### PR TITLE
HTML escaping

### DIFF
--- a/lib/formtools/widgets/textarea.js
+++ b/lib/formtools/widgets/textarea.js
@@ -2,6 +2,18 @@
 var formist = require('formist'),
     utils = require('../../utils');
 
+var toEscape = {
+        '<': '&lt;',
+        '>': '&gt;' };
+
+var escape = function (value) {
+
+    return String(value || '').replace(/[<>]/g, function (char) {
+        return toEscape[char];
+    });
+
+};
+
 module.exports = function (attrs) {
 
     return function (name, field, value) {
@@ -46,7 +58,7 @@ module.exports = function (attrs) {
 
         // add the value if there is one
         if (value !== undefined && value !== null) {
-            o.attributes.value = value;
+            o.attributes.value = escape(value);
         }
 
         return new formist.Field('textarea', o);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express-session": "1.0.x",
     "printf": "0.2.x",
     "chalk": "~0.4.0",
-    "formist": "0.1.8",
+    "formist": "0.1.10",
     "clone": "0.1.15"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR solves some basic issues with the editing forms.

If you choose the textarea widget for a field, and fill it with HTML (including the tag `</textarea>`) things break pretty quickly. If you choose the text widget (or let it default to this) for a field, and fill it with a string (including a "), well, it breaks again.

This PR solves those issues.
