### PR TITLE
Value transform

### DIFF
--- a/lib/formtools/plugin.js
+++ b/lib/formtools/plugin.js
@@ -198,7 +198,8 @@ var formConfigDefault = function(keyName,schemaConfig,formConfig){
         fieldset: formConfig.fieldset, // defaults to undefined
         widget: formConfig.widget, // defaults to undefined
         required: (formConfig.required === true), // defaults to false
-        query: formConfig.query || {}
+        query: formConfig.query || {},
+        transform: formConfig.transform // defaults to undefined
     };
 
     // default the required properties for query
@@ -220,6 +221,7 @@ var formConfigDefault = function(keyName,schemaConfig,formConfig){
     obj.create.required = (formConfig.create.required === undefined) ? obj.required : formConfig.create.required;
     obj.create.placeholder = formConfig.create.placeholder || formConfig.placeholder;
     obj.create.query = formConfig.create.query || {};
+    obj.create.transform = formConfig.create.transform || formConfig.transform;
 
     // default the required properties for query
     obj.create.query.filter = obj.create.query.filter || obj.query.filter || undefined;
@@ -236,6 +238,7 @@ var formConfigDefault = function(keyName,schemaConfig,formConfig){
     obj.edit.required = (formConfig.edit.required === undefined) ? obj.required : formConfig.edit.required;
     obj.edit.placeholder = formConfig.edit.placeholder || formConfig.placeholder;
     obj.edit.query = formConfig.edit.query || {};
+    obj.edit.transform = formConfig.edit.transform || formConfig.transform;
 
     // default the required properties for query
     obj.edit.query.filter = obj.edit.query.filter || obj.query.filter || undefined;

--- a/routes/recordOverview.js
+++ b/routes/recordOverview.js
@@ -19,7 +19,7 @@ var route = function (req, res) {
 
 			}
 
-			req.linz.model.overview.renderer.call(this, req.linz.record, req.linz.model, req.linz, function (err, content) {
+			req.linz.model.overview.renderer.call(this, req.linz.record, req.linz.model, function (err, content) {
 				locals.overviewBody = content;
 				callback(null);
 			});

--- a/routes/recordSave.js
+++ b/routes/recordSave.js
@@ -1,38 +1,67 @@
 var formist = require('formist'),
 	linz = require('../'),
-    model = require('../lib/formtools/model');
+    model = require('../lib/formtools/model'),
+    async = require('async'),
+    utils = require('../lib/utils');
 
 /* GET /admin/:model/:id/overview */
 var route = function (req, res, next) {
 
-    req.linz.model.findById(req.params.id).exec(function (err, record) {
+    async.waterfall([
+
+        function (done) {
+
+            req.linz.model.getForm(function(err,form){
+
+                // retrieve form information, for use in next function
+                req.linz.model.form = form;
+
+                // we're done
+                return done(null, form);
+
+            });
+
+        },
+
+        function (form, done) {
+
+            req.linz.model.findById(req.params.id).exec(function (err, record) {
+
+                if (err) {
+                    return next(err);
+                }
+
+                // clean the body
+                model.clean(req.body, req.linz.model);
+
+                // loop over each key in the body
+                // update each field passed to us (as long as its from the schema)
+                Object.keys(req.linz.model.schema.paths).forEach(function (field) {
+
+                    if (field !== '_id' && req.body[field] !== undefined) {
+
+                        // merge edit object back into form object (overrides)
+                        utils.merge(form[field], form[field]['edit'] || {});
+
+                        // go through the transform function if one exists
+                        record[field] = (form[field].transform) ? form[field].transform(req.body[field], 'beforeSave') : req.body[field];
+                    }
+
+                });
+
+                record.save(req, done);
+
+            });
+
+        }
+
+    ], function (err, updatedDocument) {
 
         if (err) {
             return next(err);
         }
 
-        // clean the body
-        model.clean(req.body, req.linz.model);
-
-        // loop over each key in the body
-        // update each field passed to us (as long as its from the schema)
-        Object.keys(req.linz.model.schema.paths).forEach(function (field) {
-
-            if (field !== '_id' && req.body[field] !== undefined) {
-                record[field] = req.body[field];
-            }
-
-        });
-
-        record.save(req, function (saveError, updatedDocument) {
-
-            if (saveError) {
-                return next(saveError);
-            }
-
-            return res.redirect(linz.api.getAdminLink(req.linz.model.modelName, 'overview', updatedDocument._id));
-
-        });
+        return res.redirect(linz.api.getAdminLink(req.linz.model.modelName, 'overview', updatedDocument._id));
 
     });
 

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -160,6 +160,7 @@ describe('formtools', function () {
                     default: true
                 },
                 description: String,
+                favourites: Array,
                 groups: String,
                 states: Array,
                 category: {
@@ -195,6 +196,11 @@ describe('formtools', function () {
 					},
                     description: {
                         type: 'text'
+                    },
+                    favourites: {
+                        transform: function (value, mode) {
+                            return value;
+                        }
                     },
 					groups: {
                         list: list
@@ -237,6 +243,7 @@ describe('formtools', function () {
                     default: true
                 },
                 description: String,
+                favourites: Array,
                 groups: String,
                 states: Array,
                 category: {
@@ -334,6 +341,21 @@ describe('formtools', function () {
                         },
                         edit: {
                             fieldset: 'Edit fieldset'
+                        }
+                    },
+                    favourites: {
+                        transform: function transformFavourites (value, mode) {
+                            return value;
+                        },
+                        create: {
+                            transform: function transformFavouritesCreate (value, mode) {
+                                return value;
+                            }
+                        },
+                        edit: {
+                            transform: function transformFavouritesEdit(value, mode) {
+                                return value;
+                            }
                         }
                     },
                     groups: {
@@ -1495,6 +1517,16 @@ describe('formtools', function () {
                         (formOpts['category'].query.label === undefined).should.equal(true);
                     });
 
+                    it('should set transform if provided', function () {
+                        formOpts['favourites'].should.have.property('transform');
+                        (typeof formOpts['favourites'].transform === 'function').should.equal(true);
+                    });
+
+                    it('should set transform to undefined, if none provided', function () {
+                        formOpts['category'].should.have.property('transform');
+                        (formOpts['category'].transform === undefined).should.equal(true);
+                    });
+
                 });
             }); // end describe('form default')
 
@@ -1593,6 +1625,19 @@ describe('formtools', function () {
                         (formOpts['category'].create.query.sort === undefined).should.equal(true);
                         (formOpts['category'].create.query.select === undefined).should.equal(true);
                         (formOpts['category'].create.query.label === undefined).should.equal(true);
+                    });
+
+                    it('should inherit transform', function () {
+                        formOpts['category'].create.should.have.property('transform');
+                        (formOpts['category'].create.transform === undefined).should.equal(true);
+                    });
+
+                    it('should override transform', function () {
+                        overridesFormOpts['favourites'].should.have.property('transform');
+                        (typeof overridesFormOpts['favourites'].transform === 'function').should.equal(true);
+                        overridesFormOpts['favourites'].create.should.have.property('transform');
+                        (typeof overridesFormOpts['favourites'].create.transform === 'function').should.equal(true);
+                        overridesFormOpts['favourites'].create.transform.name.should.equal('transformFavouritesCreate');
                     });
 
     			});
@@ -1694,6 +1739,19 @@ describe('formtools', function () {
                         (overridesFormOpts['category'].edit.query.sort === undefined).should.equal(true);
                         (overridesFormOpts['category'].edit.query.select === undefined).should.equal(true);
                         (overridesFormOpts['category'].edit.query.label === undefined).should.equal(true);
+                    });
+
+                    it('should inherit transform', function () {
+                        formOpts['category'].edit.should.have.property('transform');
+                        (formOpts['category'].edit.transform === undefined).should.equal(true);
+                    });
+
+                    it('should override transform', function () {
+                        overridesFormOpts['favourites'].should.have.property('transform');
+                        (typeof overridesFormOpts['favourites'].transform === 'function').should.equal(true);
+                        overridesFormOpts['favourites'].edit.should.have.property('transform');
+                        (typeof overridesFormOpts['favourites'].edit.transform === 'function').should.equal(true);
+                        overridesFormOpts['favourites'].edit.transform.name.should.equal('transformFavouritesEdit');
                     });
 
                 });


### PR DESCRIPTION
This PR provides configuration to transform field values, prior to saving them in the database. It follows the following workflow:
- create / edit form is rendered
- users fills in data
- users hits save, and form is POSTed
- linz goes through each field, and if found, runs a transform function
- linz overrides the value from the form post and saves to the database

Transform methods are provided in the form key of the linz.formtools.plugin configuration object:

``` js
redirects: {
    label: 'Label',
    transform: function transform (value, mode) {
        return value.split(',');
    }
}
```

Mode will be set to `beforeSave`. In time, we might provide a means to transform a value between database retrieval and form generation, and the `mode` argument allows the user to determine at which point the transform function is being execute. Although, it may not matter to the user.

If you like it, it's ready to pull.
