### PR TITLE
Refactored the middleware for rendering overviews

### DIFF
--- a/middleware/recordOverview.js
+++ b/middleware/recordOverview.js
@@ -6,7 +6,6 @@ module.exports = function () {
 	return function (req, res, next) {
 
 		req.linz.model = req.linz.get('models')[req.params.model];
-        var record = {};
 
         async.series([
 
@@ -20,59 +19,10 @@ module.exports = function () {
                     }
 
                     req.linz.record = doc;
-                    record = doc.toObject({ virtuals: true});
 
                     return cb(null);
 
                 });
-
-
-            },
-
-            // check if doc can be edited
-            function (cb) {
-
-                // skip this if canEdit is not define for model
-                if (!req.linz.record.canEdit) {
-                    return cb(null);
-                }
-
-                req.linz.record.canEdit(function (err, result, message) {
-
-                    if (err) {
-                        return cb(err);
-                    }
-
-                    record.edit = { disabled: !result, message: message };
-
-                    return cb(null);
-
-                });
-
-
-
-            },
-
-            // check if doc can be deleted
-            function (cb) {
-
-                // skip this if canDelete is not define for model
-                if (!req.linz.record.canDelete) {
-                    return cb(null);
-                }
-
-                req.linz.record.canDelete(function (err, result, message) {
-
-                    if (err) {
-                        return cb(err);
-                    }
-
-                    record.delete = { disabled: !result, message: message };
-
-                    return cb(null);
-
-                });
-
 
 
             },
@@ -110,8 +60,6 @@ module.exports = function () {
             }
 
         ], function (err, results) {
-
-            req.linz.record = record;
 
             return next(err);
 

--- a/routes/recordOverview.js
+++ b/routes/recordOverview.js
@@ -47,7 +47,65 @@ var route = function (req, res) {
 
 			});
 
-		}
+		},
+
+        function (cb) {
+
+            // the overview renderer doesn't require a mongoose object
+            // but rather an object literal with a few extra properties
+            locals.record = req.linz.record.toObject({ virtuals: true});
+
+            return cb(null);
+
+        },
+
+        // check if doc can be edited
+        function (cb) {
+
+            // skip this if canEdit is not define for model
+            if (!locals.record.canEdit) {
+                return cb(null);
+            }
+
+            locals.record.canEdit(function (err, result, message) {
+
+                if (err) {
+                    return cb(err);
+                }
+
+                record.edit = { disabled: !result, message: message };
+
+                return cb(null);
+
+            });
+
+
+
+        },
+
+        // check if doc can be deleted
+        function (cb) {
+
+            // skip this if canDelete is not define for model
+            if (!locals.record.canDelete) {
+                return cb(null);
+            }
+
+            locals.record.canDelete(function (err, result, message) {
+
+                if (err) {
+                    return cb(err);
+                }
+
+                record.delete = { disabled: !result, message: message };
+
+                return cb(null);
+
+            });
+
+
+
+        }
 
 	], function (err, results) {
 


### PR DESCRIPTION
Hey @sandytrinh,

As per our discussions, I've refactored this bit of code so that overview renderers receive a full mongoose object, but the view renderer receives an object literal with a few extra properties as its expecting.

Can you please take a quick look, I'd like to push this into master before we branch again.

Thanks.
