### PR TITLE
Add the ability to pass in dynamic attributes for the group action anchor tag

### DIFF
--- a/views/modelIndex/header.jade
+++ b/views/modelIndex/header.jade
@@ -35,11 +35,11 @@
 					ul.dropdown-menu(role='menu')
 						for groupAction in model.grid.groupActions
 							li(role='presentation')
+								- groupAction.attributes = groupAction.attributes || {}
 								if groupAction.useModal
-									- groupAction.attributes = groupAction.attributes || {}
 									- groupAction.attributes['data-linz-control'] = 'group-action'
 									- groupAction.attributes['data-target'] = '#groupActionModal'
-								a(role='menuitem' tabindex='-1' href=linz.api.getAdminLink(model, groupAction.action))&attributes((groupAction.attributes) ? groupAction.attributes : {})= groupAction.label
+								a(role='menuitem' tabindex='-1' href=linz.api.getAdminLink(model, groupAction.action))&attributes(groupAction.attributes)= groupAction.label
 
 	if model.grid.export && model.grid.export.enable
 		.export


### PR DESCRIPTION
This PR adds the ability to further customise a group action inside linz. User will be able to pass in an attributes object to add additional attribute fields for the rendered anchor tag. See below example.

```
groupActions: [
    {
        label: 'Send group email',
        action: 'group-email',
        attributes: {
            'data-mms-control': 'group-email',
            'href': 'mailto:user@example.com'
        }
    }
]
```

The above DSL would produce the following markup

```
<a role="menuitem" tabindex="-1" href="mailto:user@example.com" data-mms-control="group-email">Send group email</a>

```

This PR also check for a new variable `userModal` which specify is a group action requires to use a modal e.g. the following example would produce 2 different attribute fields for each of the group action anchor tags, note the missing `data-linz-control="group-action" data-target="#groupActionModal"` from the second anchor tag.

```
groupActions: [
    {
        label: 'Assign BDM',
        action: 'assign/bdm',
        useModal: true
    },
    {
        label: 'Assign RM',
        action: 'assign/rm',
        useModal: false
    }
]
```

```
      <li role="presentation"><a role="menuitem" tabindex="-1" href= "/admin/model/mmsMember/assign/bdm" data-linz-control="group-action" data-target="#groupActionModal">Assign BDM</a></li>
      <li role="presentation"><a role="menuitem" tabindex="-1" href= "/admin/model/mmsMember/assign/rm">Assign RM</a></li>
```

@smebberson This is ready for review.
