### PR TITLE
Add a flag to by pass the presave hook in formtool

### DIFF
--- a/lib/formtools/plugin.js
+++ b/lib/formtools/plugin.js
@@ -547,7 +547,13 @@ var plugin = module.exports = function formtoolsPlugin (schema, options) {
 
 	schema.pre('save', function (next, req, callback) {
 
-		this.dateModified = new Date();
+        // add ability to by pass the pre save hooks
+        // defaults to true
+        var bPreSave = !(req.modelPreSave === false);
+
+        if (bPreSave) {
+		  this.dateModified = new Date();
+        }
 
 		return next(callback, req);
 


### PR DESCRIPTION
This PR adds a flag that can be added to req to by-pass the presave middleware added by the formtool plugin. This is require for import process where user can provide all data.

@smebberson Can you think of a better way to achieve this?

I thought added the variable to req would be best as it can grows rather passing it in as parameters which means every function that calls save will need to be updated everything we need to add in new arguments.
