### PR TITLE
Set export button to be visible at 1050px

### DIFF
--- a/public/src/css/includes/index.less
+++ b/public/src/css/includes/index.less
@@ -342,7 +342,8 @@
 
 }
 
-@media (min-width: @screen-lg-min) {
+// visible for desktop screens
+@media (min-width: 1050px) {
 
 	.model-actions {
 


### PR DESCRIPTION
Button is not visible for mobile or iPad.

@smebberson This is ready for review!
