### PR TITLE
Fix 'Invalid Date' issue for date input field in IE10

### DIFF
--- a/lib/formtools/form.js
+++ b/lib/formtools/form.js
@@ -206,11 +206,11 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
                 switch (field.type) {
 
                     case 'date':
-                        fieldValue = (r[fieldName] !== undefined ? moment(r[fieldName]).format('YYYY-MM-DD') : null) || defaultValue;
+                        fieldValue = ((r[fieldName] !== undefined && r[fieldName] !== null) ? moment(r[fieldName]).format('YYYY-MM-DD') : null) || defaultValue;
                         break;
 
                     case 'datetime':
-                        fieldValue = (r[fieldName] !== undefined ? r[fieldName].toISOString().slice(0,23) : defaultValue) || defaultValue;
+                        fieldValue = ((r[fieldName] !== undefined && r[fieldName] !== null) ? r[fieldName].toISOString().slice(0,23) : defaultValue) || defaultValue;
                         break;
 
                     case 'boolean':


### PR DESCRIPTION
This PR fixes 'Invalid Date' issue for date input fields that are displayed in IE10. This error occurs when formtools attempting to parse a null value as date and return 'Invalid Date' string which is rendered in IE10 and hence saving this value would throw an error.

@smebberson This is ready for review!
