### PR TITLE
Export exclusion fields issue

### DIFF
--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -247,11 +247,8 @@ module.exports = {
                     return next(formErr);
                 }
 
-
-                var excludedFieldNames = grid.export.exclusions.split(','),
+                var excludedFieldNames = grid.export.exclusions.concat(',__v').split(','),
                 fieldLabels = {};
-
-                excludedFieldNames.push('__v');
 
                 // get a list of field names
                 req.linz.model.schema.eachPath(function (pathname, schemaType) {


### PR DESCRIPTION
This PR fixes an issue for export exclusion fields where exclusion fields matches were making a partial text match due to the excludedFields being converted to a string (see code line 251)

This was causing an issue if you have a field name with the same prefix e.g. `email` and `emails` would be excluded if the `emails` field is added to the exclusion list.

@smebberson This is ready for review!
