### PR TITLE
Fixes model index pages without filters

### DIFF
--- a/lib/helpers-models.js
+++ b/lib/helpers-models.js
@@ -22,9 +22,9 @@ exports.loadModels = function loadModels (dir, cb) {
     try {
         files = fs.readdirSync(dir);
     } catch (e) {
-        debugConfigs('Error: Unable to load models from directory, %s', dir);
+        debugModels('Error: Unable to load models from directory, %s', dir);
         error.log(e.stack + '\n');
-        return configs;
+		return models;
     }
 
     async.each(files, function(file, done) {

--- a/linz.js
+++ b/linz.js
@@ -247,10 +247,8 @@ Linz.prototype.loadModels = function (cb) {
 	// set the default models path
 	this.set('models path', path.resolve(this.get('cwd'), 'models'), false);
 
-	var modelsPath = this.get('models path');
-
     // load in the models (non-standard callback as loadModels handles all errors)
-    helpersModels.loadModels(modelsPath, function (models) {
+    helpersModels.loadModels(this.get('models path'), function (models) {
 
         _this.set('models', models || []);
 
@@ -413,7 +411,7 @@ Linz.prototype.defaultConfiguration = function (cb) {
 	if (this.get('request logging') === true) routesManager.setupLoggingRoutes();
 
 	// store the cwd
-	this.set('cwd', process.cwd());
+	this.set('cwd', process.cwd(), false);
 
 	// place holder for the models, which get loaded in next
 	this.set('models', []);

--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -7,12 +7,19 @@ module.exports = function  (req, res, next) {
         getModelIndex: function getModelIndex () {
 
             // set up session control
-            var session = req.session[req.params.model] = req.session[req.params.model] || {};
+            var session = req.session[req.params.model] = req.session[req.params.model] || {},
+                previousFormData = null;
+
             session.grid = session.grid || {};
             session.grid.formData = session.grid.formData || {};
 
             if (Object.keys(req.body).length) {
                 session.grid.formData = req.body;
+            }
+
+            // if the pageSize has been changed, reset the page index
+            if (previousFormData !== null && previousFormData.pageSize !== undefined && session.grid.formData.pageSize !== undefined && previousFormData.pageSize !== session.grid.formData.pageSize) {
+                session.grid.formData.page = 1;
             }
 
             var records = [],

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -258,8 +258,11 @@ module.exports = {
                         return;
                     }
 
+                    // if the pathname doesn't exist in form, default the label to the pathname itself
+                    var ind = (form[pathname] === undefined) ? pathname : form[pathname].label;
+
                     // get a list of fields by the label ready for sorting
-                    fieldLabels[form[pathname].label] = pathname;
+                    fieldLabels[ind] = pathname;
 
                 });
 

--- a/public/js/model/index.js
+++ b/public/js/model/index.js
@@ -4,7 +4,7 @@
 
     /* FILTERS */
 
-    if ($('.selectedFilters').val().length > 0) {
+    if ($('.selectedFilters').length && $('.selectedFilters').val().length > 0) {
         toggleFilterBox('show');
     }
 
@@ -275,13 +275,24 @@
     // trigger a click of the 'filter' button
     function triggerSubmit () {
 
-        // click the button
-        $('.filters').find(':submit').click();
+        // is there a filter submit button?
+        // model indexes without filters don't have them
+        if ($('.filters').find(':submit').length) {
 
-        // add spinning icon to Filter dropdown to indicate page is loading
-        var icon = $('.addFilterBtn').find('.fa-filter');
-        icon.removeClass('fa-filter');
-        icon.addClass('fa-spinner fa-spin');
+            // click the button
+            $('.filters').find(':submit').click();
+
+            // add spinning icon to Filter dropdown to indicate page is loading
+            var icon = $('.addFilterBtn').find('.fa-filter');
+            icon.removeClass('fa-filter');
+            icon.addClass('fa-spinner fa-spin');
+
+            return;
+
+        }
+
+        // click the button
+        $('.filters').submit();
 
     }
 

--- a/views/modelIndex/filters.jade
+++ b/views/modelIndex/filters.jade
@@ -1,5 +1,5 @@
-if Object.keys(model.grid.filters).length
-	.model-filters
+.model-filters
+	if Object.keys(model.grid.filters).length
 		.dropdown.addFilterBtn
 			a(data-toggle='dropdown', role='button', class="btn btn-default")
 				i.fa.fa-filter
@@ -10,11 +10,12 @@ if Object.keys(model.grid.filters).length
 					li
 						a.control-addFilter(data-filter-field='' + key + '')= filterField['label']
 						span.controlField!= filterField.formControls
-		form.filters(method='post', role='form')
-			input.page(type='hidden', name='page', value=''+ page +'')
-			input.pageSize(type='hidden', name='pageSize', value=''+ pageSize +'')
-			input.selectedFilters(type='hidden', name='selectedFilters', value='' + ((form.selectedFilters) ? form.selectedFilters : '') + '')
-			input.selectedSort(type='hidden', name='sort', value='' + form.sort + '')
+	form.filters(method='post', role='form')
+		input.page(type='hidden', name='page', value=''+ page +'')
+		input.pageSize(type='hidden', name='pageSize', value=''+ pageSize +'')
+		input.selectedFilters(type='hidden', name='selectedFilters', value='' + ((form.selectedFilters) ? form.selectedFilters : '') + '')
+		input.selectedSort(type='hidden', name='sort', value='' + form.sort + '')
+		if Object.keys(model.grid.filters).length
 			.filter-list
 				if model.grid.activeFilters
 					for activeFilter, fieldName in model.grid.activeFilters

--- a/views/modelIndex/paging.jade
+++ b/views/modelIndex/paging.jade
@@ -1,5 +1,5 @@
-if pagination
-	.model-paging
+.model-paging
+	if pagination
 		.records
 			span Showing
 			select.pagination.form-control
@@ -9,11 +9,11 @@ if pagination
 					else
 						option(value=i+1)= i+1
 			span of #{pages} pages
-		.page-size
-			select.pagination-size.form-control
-				- for ps in pageSizes
-					if pageSize === ps
-						option(value=ps, selected)= ps
-					else
-						option(value=ps)= ps
-			span records per page
+	.page-size
+		select.pagination-size.form-control
+			- for ps in pageSizes
+				if pageSize === ps
+					option(value=ps, selected)= ps
+				else
+					option(value=ps)= ps
+		span records per page


### PR DESCRIPTION
The data grid sorting/pagination on model index pages without filters was essentially broken. These changes make them work again.

@sandytrinh, this is just a small one and read for review.
