### PR TITLE
Provide login and logout middleware to return array of functions

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -39,9 +39,11 @@ module.exports = {
 		return callback(true);
 	},
 
-	'login middleware': function() {
-		return [require('../').middleware.authenticate('linz-local')];
-	},
+	// sets an array of middleware functions to handle login
+	'login middleware': [require('../middleware-public/authenticate')('linz-local')],
+
+	// sets an array of middleware functions to handle logout
+	'logout middleware': [require('../routes/adminLogout')],
 
 	// cache
 	'disable navigation cache': false

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -46,7 +46,9 @@ module.exports = {
 	},
 
 	// sets an array of middleware functions to handle logout
-	'logout middleware': [require('../middleware-public/logout')],
+	'logout middleware': {
+		get: [require('../middleware-public/logout')]
+	},
 
 	// cache
 	'disable navigation cache': false

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -42,7 +42,7 @@ module.exports = {
 	// sets an array of middleware functions to handle login
 	'login middleware': {
 		get: [require('../middleware-public/login').get],
-		post: [require('../middleware-public/authenticate')('linz-local')]
+		post: [require('../middleware-public/authenticate')('linz-local', { failureFlash: true })]
 	},
 
 	// sets an array of middleware functions to handle logout

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -39,6 +39,10 @@ module.exports = {
 		return callback(true);
 	},
 
+	'login middleware': function() {
+		return [require('../').middleware.authenticate('linz-local')];
+	},
+
 	// cache
 	'disable navigation cache': false
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -40,10 +40,13 @@ module.exports = {
 	},
 
 	// sets an array of middleware functions to handle login
-	'login middleware': [require('../middleware-public/authenticate')('linz-local')],
+	'login middleware': {
+		get: [require('../middleware-public/login').get],
+		post: [require('../middleware-public/authenticate')('linz-local')]
+	},
 
 	// sets an array of middleware functions to handle logout
-	'logout middleware': [require('../routes/adminLogout')],
+	'logout middleware': [require('../middleware-public/logout')],
 
 	// cache
 	'disable navigation cache': false

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -43,7 +43,7 @@ module.exports = function (pp) {
 
 			if (!user) {
 				debugSession('Could not find user ' + username);
-				return done(null, false);
+				return done(null, false, { message: 'Unauthorised' });
 			}
 
 	        // check if a verifyPassword function is defined for user model

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -43,7 +43,7 @@ module.exports = function (pp) {
 
 			if (!user) {
 				debugSession('Could not find user ' + username);
-				return done(null, false, { message: 'Unauthorised' });
+				return done(null, false);
 			}
 
 	        // check if a verifyPassword function is defined for user model
@@ -68,7 +68,7 @@ module.exports = function (pp) {
 	            } else {
 
 	                debugSession('Password did not match for user ' + username);
-	                return done(null, false, { message: 'Invalid password' });
+	                return done(null, false, 'Invalid password');
 
 	            }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -38,8 +38,8 @@ exports.setupAdminRoutes = function () {
 	router.get('*', middleware.linz, linz.middleware.exclusions(middleware.adminEnsureAuthenticated(), middleware.navigation));
 	router.post('*', middleware.linz, linz.middleware.exclusions(middleware.adminEnsureAuthenticated(), middleware.navigation));
 	router.get('/', routes.adminHome);
-	router.get('/login', routes.adminLogin.get);
-	router.post('/login', linz.get('login middleware'));
+	router.get('/login', linz.get('login middleware').get);
+	router.post('/login', linz.get('login middleware').post);
 	router.get('/logout', linz.get('logout middleware'));
 
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -39,8 +39,8 @@ exports.setupAdminRoutes = function () {
 	router.post('*', middleware.linz, linz.middleware.exclusions(middleware.adminEnsureAuthenticated(), middleware.navigation));
 	router.get('/', routes.adminHome);
 	router.get('/login', routes.adminLogin.get);
-	router.post('/login', linz.get('login middleware')());
-	router.get('/logout', routes.adminLogout);
+	router.post('/login', linz.get('login middleware'));
+	router.get('/logout', linz.get('logout middleware'));
 
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -40,7 +40,7 @@ exports.setupAdminRoutes = function () {
 	router.get('/', routes.adminHome);
 	router.get('/login', linz.get('login middleware').get);
 	router.post('/login', linz.get('login middleware').post);
-	router.get('/logout', linz.get('logout middleware'));
+	router.get('/logout', linz.get('logout middleware').get);
 
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -39,7 +39,7 @@ exports.setupAdminRoutes = function () {
 	router.post('*', middleware.linz, linz.middleware.exclusions(middleware.adminEnsureAuthenticated(), middleware.navigation));
 	router.get('/', routes.adminHome);
 	router.get('/login', routes.adminLogin.get);
-	router.post('/login', linz.middleware.authenticate('linz-local'));
+	router.post('/login', linz.get('login middleware')());
 	router.get('/logout', routes.adminLogout);
 
 };

--- a/middleware-public/authenticate.js
+++ b/middleware-public/authenticate.js
@@ -43,7 +43,7 @@ module.exports = function (strategy, opts) {
                     }
 
                     flash.type = flash.type || 'error';
-                    flash.message = flash.message || info.message || info || 'Unauthorised';
+                    flash.message = flash.message || (info ? info.message ? info.message : info : undefined) || 'Unauthorised';
 
                     if (typeof flash.message === 'string') {
                         req.flash(flash.type, flash.message);

--- a/middleware-public/authenticate.js
+++ b/middleware-public/authenticate.js
@@ -1,4 +1,4 @@
-var linz = require('../');
+
 
 /**
  * This middleware provides a hook for those using a custom login process to remain integrated
@@ -16,6 +16,8 @@ module.exports = function (strategy, opts) {
     opts = opts || {};
 
     return function (req, res, next) {
+
+        var linz = require('../');
 
         // call the authenticate method, passing in the strategy, our custom call back and req, res and next
         linz.passport.authenticate(strategy, function (err, user, info) {

--- a/middleware-public/authenticate.js
+++ b/middleware-public/authenticate.js
@@ -43,7 +43,7 @@ module.exports = function (strategy, opts) {
                     }
 
                     flash.type = flash.type || 'error';
-                    flash.message = flash.message || (info ? info.message ? info.message : info : undefined) || 'Unauthorised';
+                    flash.message = flash.message || info.message || info || 'Unauthorised';
 
                     if (typeof flash.message === 'string') {
                         req.flash(flash.type, flash.message);

--- a/middleware-public/authenticate.js
+++ b/middleware-public/authenticate.js
@@ -43,7 +43,7 @@ module.exports = function (strategy, opts) {
                     }
 
                     flash.type = flash.type || 'error';
-                    flash.message = flash.message || info.message || info || 'Unauthorised';
+                    flash.message = flash.message || info || 'Unauthorised';
 
                     if (typeof flash.message === 'string') {
                         req.flash(flash.type, flash.message);
@@ -86,7 +86,7 @@ module.exports = function (strategy, opts) {
                     }
 
                     flash.type = flash.type || 'success';
-                    flash.message = flash.message || info.message || info || 'Successful login';
+                    flash.message = flash.message || info || 'Successful login';
 
                     if (typeof flash.message === 'string') {
                         req.flash(flash.type, flash.message);

--- a/middleware-public/index.js
+++ b/middleware-public/index.js
@@ -6,3 +6,5 @@ exports.error = require('./error');
 exports.exclusions = require('./exclusions');
 exports.originalUrl = require('./original-url');
 exports.authenticate = require('./authenticate');
+exports.logout = require('./logout');
+exports.login = require('./login');

--- a/middleware-public/login.js
+++ b/middleware-public/login.js
@@ -1,0 +1,1 @@
+module.exports = require('../routes/adminLogin');

--- a/middleware-public/logout.js
+++ b/middleware-public/logout.js
@@ -1,7 +1,5 @@
-
-
 /* GET /admin/login */
-var route = function (req, res) {
+module.exports = function (req, res) {
 
 	var linz = require('../');
 
@@ -15,5 +13,3 @@ var route = function (req, res) {
 	res.redirect((linz.get('admin path') === '' ? '/' : linz.get('admin path')));
 
 };
-
-module.exports = route;

--- a/routes/adminLogin.js
+++ b/routes/adminLogin.js
@@ -7,10 +7,11 @@ var route = {
 	get: function (req, res, next) {
 
         var linz = require('../'),
-        // check if resetPassword() is defined for user model
-        locals = {
-            hasResetPassword: linz.api.model.get(linz.get('user model')).sendPasswordResetEmail
-        };
+            loginError = req.flash('error'),
+            locals = {
+                hasResetPassword: linz.api.model.get(linz.get('user model')).sendPasswordResetEmail, // check if resetPassword() is defined for user model
+                loginErrorMsg: (!loginError.length) ? '' : loginError.toString() //set login error message
+            };
 
         // pre-render the admin view, ready to plug into the larger wrapper
         async.series([

--- a/routes/adminLogin.js
+++ b/routes/adminLogin.js
@@ -7,10 +7,9 @@ var route = {
 	get: function (req, res, next) {
 
         var linz = require('../'),
-            loginError = req.flash('error'),
             locals = {
                 hasResetPassword: linz.api.model.get(linz.get('user model')).sendPasswordResetEmail, // check if resetPassword() is defined for user model
-                loginErrorMsg: (!loginError.length) ? '' : loginError.toString() //set login error message
+                loginError: req.flash('error') //set login error message
             };
 
         // pre-render the admin view, ready to plug into the larger wrapper

--- a/routes/adminLogin.js
+++ b/routes/adminLogin.js
@@ -1,5 +1,4 @@
-var linz = require('../'),
-    path = require('path'),
+var path = require('path'),
     async = require('async');
 
 /* GET /admin/login */
@@ -7,8 +6,9 @@ var route = {
 
 	get: function (req, res, next) {
 
+        var linz = require('../'),
         // check if resetPassword() is defined for user model
-        var locals = {
+        locals = {
             hasResetPassword: linz.api.model.get(linz.get('user model')).sendPasswordResetEmail
         };
 

--- a/routes/adminLogout.js
+++ b/routes/adminLogout.js
@@ -1,7 +1,9 @@
-var linz = require('../');
+
 
 /* GET /admin/login */
 var route = function (req, res) {
+
+	var linz = require('../');
 
 	// log user out
 	req.logout();

--- a/views/login/form.jade
+++ b/views/login/form.jade
@@ -12,6 +12,7 @@
 				a(href=linz.api.url.getAdminForgotPasswordLink()) Forgot your password?
 		if loginError.length
 			div.alert.alert-danger
-				each error in loginError
-					p= error
+				ul
+					each error in loginError
+						li= error
 		button.btn.btn-primary(type='submit') Sign-in

--- a/views/login/form.jade
+++ b/views/login/form.jade
@@ -10,6 +10,6 @@
 		if hasResetPassword
 			.form-group
 				a(href=linz.api.url.getAdminForgotPasswordLink()) Forgot your password?
-		if loginErrorMsg
-			div.alert.alert-danger= loginErrorMsg
+		if loginError.length
+			div.alert.alert-danger= loginError
 		button.btn.btn-primary(type='submit') Sign-in

--- a/views/login/form.jade
+++ b/views/login/form.jade
@@ -11,5 +11,7 @@
 			.form-group
 				a(href=linz.api.url.getAdminForgotPasswordLink()) Forgot your password?
 		if loginError.length
-			div.alert.alert-danger= loginError
+			div.alert.alert-danger
+				each error in loginError
+					p= error
 		button.btn.btn-primary(type='submit') Sign-in

--- a/views/login/form.jade
+++ b/views/login/form.jade
@@ -10,4 +10,6 @@
 		if hasResetPassword
 			.form-group
 				a(href=linz.api.url.getAdminForgotPasswordLink()) Forgot your password?
+		if loginErrorMsg
+			div.alert.alert-danger= loginErrorMsg
 		button.btn.btn-primary(type='submit') Sign-in


### PR DESCRIPTION
### Problem
At the moment, applications that implements Linz, needs to define seperate `login` route before instantiation of the linz to execute their custom middleware functions on `login` request

### This PR improves the login and logout process by providing following functionality to applications using linz:
- `Linz` has added two new defaults called `login middleware` and `logout middleware`
- `login middleware` sets an array of default middleware function to be executed when `login` route is hit
- `logout middleware` sets an array of default middleware function to be executed when `logout` route is hit
- Applications can provide an array of their own middleware functions to be executed upon request to `login` and/or `logout ` routes.
- Thus, Linz allow applications to overwrite or extend the default `login` and `logout` behaviour provided by Linz.

### Usage

- Pass an array of middleware functions for login and/or logout through `settings` when you are initialising Linz in your application as follow: 

- To extend the default `login` and `logout` behaviour provided by linz:

```
settings['login middleware'] = {
    get: [
        function A (req, res, next) {
                  function A code here...
                  next();
        },
        ........ more functions here,
       linz.middleware.login.get
    ],
    post: [
        function A (req, res, next) {
                  function A code here...
                  next();
        },
        ........ more functions here,
        linz.middleware.authenticate
    ] 
};

settings['logout middleware'] = {
    get: [
        function A (req, res, next) {
                  function A code here...
                  next();
        },
       ....... more functions here,
       linz.middleware.logout
    ]
};
```

__Note:__ You can chain your middleware functions and default `login` and `logout` middleware function provided by linz in any order.

- To overwrite default `login` and `logout ` functionality provided by Linz
   
```
settings['login middleware'] = {
    get: [
        function A (req, res, next) {
                  function A code here...
                  next();
        },
        function B (req, res, next) {
                  function B code here...
                  next();
        },
        ............. more functions here,
        function N (req, res, next) {
                function N code here....
        }
    ],
    post: [
        function A (req, res, next) {
                  function A code here...
                  next();
        },
        function B (req, res, next) {
                  function B code here...
                  next();
        },
        ............. more functions here,
        function N (req, res, next) {
                function N code here....
        }
    ] 
};

settings['logout middleware'] = {
    get: [
        function A (req, res, next) {
                  function A code here...
                  next();
        },
        function B (req, res, next) {
                  function B code here...
                  next();
        },
       ....... more functions here,
       function N (req, res, next) {
             function N code here....;
       }
    ]
};

// initialise Linz with the settings, and other optional arguments
linz.init(settings, arg2, arg3, arg4, arg5);
```