### PR TITLE
Various bug fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,5 +18,7 @@
         "no-trailing-spaces": 1,
         "no-process-env": 0,
         "no-process-exit": 0
-    }
+    },
+    # if you are receiving errors for eslint, comment out the line below or upgrade to 7.2.2+
+    "extends": "eslint:recommended"
 }

--- a/lib/api/formtools/grid.js
+++ b/lib/api/formtools/grid.js
@@ -17,33 +17,38 @@ function renderToolbarItems (req, res, modelName, cb) {
         throw new Error('modelName is required and must be of type String and cannot be empty.');
     }
 
-    var model = linz.api.model.get(modelName),
-        settings = model.linz.formtools.grid;
+    linz.api.model.grid(req.user, modelName, function (err, grid) {
 
-    if (!settings.toolbarItems.length) {
-        return cb(null);
-    }
-
-    async.each(settings.toolbarItems, function (item, itemDone) {
-
-        if (!item.renderer) {
-            return itemDone(new Error('Renderer function is missing for toolbar item: ' + require('util').inspect(item) + '. Check your \'' + modelName + '\' model for more details.'));
+        if (err) {
+            return cb(err);
         }
 
-        // this is a custom action, let's execute the function to get the HTML markup
-        item.renderer(req, res, function (itemErr, html) {
+        if (!grid.toolbarItems.length) {
+            return cb(null);
+        }
 
-            if (itemErr) {
-                return itemDone(itemErr);
+        async.each(grid.toolbarItems, function (item, itemDone) {
+
+            if (!item.renderer) {
+                return itemDone(new Error('Renderer function is missing for toolbar item: ' + require('util').inspect(item) + '. Check your \'' + modelName + '\' model for more details.'));
             }
 
-            item.html = html;
+            // this is a custom action, let's execute the function to get the HTML markup
+            item.renderer(req, res, function (itemErr, html) {
 
-            return itemDone(null);
+                if (itemErr) {
+                    return itemDone(itemErr);
+                }
+
+                item.html = html;
+
+                return itemDone(null);
+            });
+
+        }, function (itemErr) {
+            return cb(itemErr, grid.toolbarItems);
         });
 
-    }, function (itemErr) {
-        return cb(itemErr, settings.toolbarItems);
     });
 
 }
@@ -55,37 +60,46 @@ function renderToolbarItems (req, res, modelName, cb) {
  * @return {Object} or undefined
  * @api public
  */
-function renderFilters (modelName, cb) {
+function renderFilters (user, modelName, cb) {
+
+    if (!user) {
+        throw new Error('user is required.');
+    }
 
     if (typeof modelName !== 'string' || !modelName.length) {
         throw new Error('modelName is required and must be of type String and cannot be empty.');
     }
 
-    var model = linz.api.model.get(modelName),
-        settings = model.linz.formtools.grid;
+    linz.api.model.grid(user, modelName, function (err, grid) {
 
-    if (!Object.keys(settings.filters).length) {
-        return cb(null);
-    }
+        if (err) {
+            return cb(err);
+        }
 
-    async.each(Object.keys(settings.filters), function (fieldName, filtersDone) {
+        if (!Object.keys(grid.filters).length) {
+            return cb(null);
+        }
 
-        // call the filter renderer and update the content with the result
-        settings.filters[fieldName].filter.renderer(fieldName, function (filterErr, result) {
+        async.each(Object.keys(grid.filters), function (fieldName, filtersDone) {
 
-            if (filterErr) {
-                return filtersDone(filterErr);
-            }
+            // call the filter renderer and update the content with the result
+            grid.filters[fieldName].filter.renderer(fieldName, function (filterErr, result) {
 
-            settings.filters[fieldName].formControls = result;
+                if (filterErr) {
+                    return filtersDone(filterErr);
+                }
 
-            return filtersDone(null);
+                grid.filters[fieldName].formControls = result;
+
+                return filtersDone(null);
+
+            });
+
+        }, function (filterErr) {
+
+            return cb(filterErr, grid.filters);
 
         });
-
-    }, function (filterErr) {
-
-        return cb(filterErr, settings.filters);
 
     });
 
@@ -100,7 +114,11 @@ function renderFilters (modelName, cb) {
  * @return {Object} or undefined
  * @api public
  */
-function renderSearchFilters(fieldNames, data, modelName, cb) {
+function renderSearchFilters(user, fieldNames, data, modelName, cb) {
+
+    if (!user) {
+        throw new Error('user is required.');
+    }
 
     if (!Array.isArray(fieldNames) || !fieldNames.length) {
         throw new Error('fieldNames is required and must be of type Array and cannot be empty.');
@@ -114,43 +132,50 @@ function renderSearchFilters(fieldNames, data, modelName, cb) {
         throw new Error('data is required and must be of type Object.');
     }
 
-    var filters = {},
-        model = linz.api.model.get(modelName),
-        settings = model.linz.formtools.grid;
+    linz.api.model.grid(user, modelName, function (err, grid) {
 
-    if (!Object.keys(settings.filters).length) {
-        return cb(null);
-    }
-
-    async.each(fieldNames, function (fieldName, filtersDone) {
-
-        if (!data[fieldName]) {
-            return filtersDone(null);
+        if (err) {
+            return cb(err);
         }
 
-        // call the filter renderer and update the content with the result
-        settings.filters[fieldName].filter.filter(fieldName, data, function (filterErr, result) {
+        if (!Object.keys(grid.filters).length) {
+            return cb(null);
+        }
 
-            if (filterErr) {
-                return filtersDone(filterErr);
+        var model = linz.api.model.get(modelName),
+            filters = {};
+
+        async.each(fieldNames, function (fieldName, filtersDone) {
+
+            if (!data[fieldName]) {
+                return filtersDone(null);
             }
 
-            filters = model.addSearchFilter(filters, result);
+            // call the filter renderer and update the content with the result
+            grid.filters[fieldName].filter.filter(fieldName, data, function (filterErr, result) {
 
-            return filtersDone(null);
+                if (filterErr) {
+                    return filtersDone(filterErr);
+                }
 
+                filters = model.addSearchFilter(filters, result);
+
+                return filtersDone(null);
+
+            });
+
+        }, function (filterErr) {
+
+            if (filterErr) {
+                return cb(filterErr);
+            }
+
+            // consolidate filters into query
+            filters = model.setFiltersAsQuery(filters);
+
+            return cb(filterErr, filters);
         });
 
-    }, function (filterErr) {
-
-        if (filterErr) {
-            return cb(filterErr);
-        }
-
-        // consolidate filters into query
-        filters = model.setFiltersAsQuery(filters);
-
-        return cb(filterErr, filters);
     });
 
 }
@@ -164,7 +189,11 @@ function renderSearchFilters(fieldNames, data, modelName, cb) {
  * @return {Object} or undefined
  * @api public
  */
-function getActiveFilters (selectedFilters, data, modelName, cb) {
+function getActiveFilters (user, selectedFilters, data, modelName, cb) {
+
+    if (!user) {
+        throw new Error('user is required.');
+    }
 
     if (!selectedFilters || !Array.isArray(selectedFilters) || !selectedFilters.length) {
         throw new Error('selectedFilters is required and must be of type Array and cannot be empty.');
@@ -178,35 +207,41 @@ function getActiveFilters (selectedFilters, data, modelName, cb) {
         throw new Error('data is required and must be of type Object.');
     }
 
-    var model = linz.api.model.get(modelName),
-        activeFilters = {},
-        settings = model.linz.formtools.grid;
+    linz.api.model.grid(user, modelName, function (err, grid) {
 
-    if (!Object.keys(settings.filters).length) {
-        return cb(null);
-    }
+        if (err) {
+            return cb(err);
+        }
 
-    async.each(selectedFilters, function (fieldName, filtersDone) {
+        if (!Object.keys(grid.filters).length) {
+            return cb(null);
+        }
 
-        // call the filter binder to render active filter form controls with form value added
-        settings.filters[fieldName].filter.bind(fieldName, data, function (filterErr, result) {
+        var activeFilters = {};
 
-            if (filterErr) {
-                return filtersDone(filterErr);
-            }
+        async.each(selectedFilters, function (fieldName, filtersDone) {
 
-            activeFilters[fieldName] = {
-                label: settings.filters[fieldName].label,
-                controls: result
-            }
+            // call the filter binder to render active filter form controls with form value added
+            grid.filters[fieldName].filter.bind(fieldName, data, function (filterErr, result) {
 
-            return filtersDone(null);
+                if (filterErr) {
+                    return filtersDone(filterErr);
+                }
+
+                activeFilters[fieldName] = {
+                    label: grid.filters[fieldName].label,
+                    controls: result
+                }
+
+                return filtersDone(null);
+
+            });
+
+        }, function (filterErr) {
+
+            return cb(filterErr, activeFilters);
 
         });
-
-    }, function (filterErr) {
-
-        return cb(filterErr, activeFilters);
 
     });
 

--- a/lib/formtools/form.js
+++ b/lib/formtools/form.js
@@ -217,31 +217,41 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
 
                 var fieldValue;
 
-                switch (field.type) {
+                // if we have a transpose function, let's use it
+                // otherwise, fall back to default processing
+                if (field.transpose) {
 
-                    case 'date':
+                    fieldValue = field.transpose(r[fieldName]);
+
+                } else {
+
+                    switch (field.type) {
+
+                        case 'date':
                         fieldValue = ((r[fieldName] !== undefined && r[fieldName] !== null) ? moment(r[fieldName]).format('YYYY-MM-DD') : null) || defaultValue;
                         break;
 
-                    case 'datetime':
+                        case 'datetime':
                         fieldValue = ((r[fieldName] !== undefined && r[fieldName] !== null) ? r[fieldName].toISOString().slice(0,23) : defaultValue) || defaultValue;
                         break;
 
-                    case 'boolean':
+                        case 'boolean':
                         fieldValue = (r[fieldName] !== undefined) ? utils.asBoolean(r[fieldName]) : defaultValue;
                         break;
 
-                    case 'array':
+                        case 'array':
                         fieldValue = (r[fieldName] !== undefined) ? r[fieldName] : defaultValue;
                         break;
 
-                    case 'documentarray':
+                        case 'documentarray':
                         fieldValue = r[fieldName];
                         break;
 
-                    default:
+                        default:
                         fieldValue = (r[fieldName] !== undefined && r[fieldName] !== null ? r[fieldName].toString() : null) || (defaultValue !== null ? defaultValue.toString() : defaultValue);
                         break;
+
+                    }
 
                 }
 

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -424,7 +424,8 @@ var formConfigDefault = function (keyName, schemaConfig, formConfig, labels) {
         widget: formConfig.widget, // defaults to undefined
         required: (formConfig.required === true), // defaults to false
         query: formConfig.query || {},
-        transform: formConfig.transform, // defaults to undefined,
+        transform: formConfig.transform, // defaults to undefined
+        transpose: formConfig.transpose, // defaults to undefined
         schema: schemaConfig.schema, // defaults to undefined
         relationship: formConfig.relationship // defaults to undefined
     };

--- a/lib/hbs-helpers.js
+++ b/lib/hbs-helpers.js
@@ -69,21 +69,6 @@ Handlebars.registerHelper('renderDiffs', function(results, options) {
             }
 
             return val;
-        },
-        renderClass = function renderClass (result) {
-            if (result.kind === 'N') {
-                return 'class="new"';
-            }
-
-            if (result.kind === 'D') {
-                return 'class="removed"';
-            }
-
-            if (result.kind === 'E') {
-                return (!result.rhs || result.rhs === null || result.rhs.length === 0) ? 'class="removed"' : 'class="edited"';
-            }
-
-            return '';
         };
 
     results.forEach(function (result, index) {
@@ -91,7 +76,6 @@ Handlebars.registerHelper('renderDiffs', function(results, options) {
         var str = '',
             lhs = result.lhs,
             rhs = result.rhs,
-            currentResult = result;
             fieldName = result.path[0];
 
         if (result.textDiff) {
@@ -119,7 +103,10 @@ Handlebars.registerHelper('renderDiffs', function(results, options) {
         if (result.kind === 'A') {
             lhs = result.item.lhs;
             rhs = result.item.rhs;
-            currentResult = result.item;
+        }
+
+        if (result.kind === 'N') {
+            rhs = rhs || '(new field, but has no value)';
         }
 
         if (index >= 1 && fieldName == results[index-1].path[0]) {
@@ -129,7 +116,7 @@ Handlebars.registerHelper('renderDiffs', function(results, options) {
         str += '<tr>'
                 + '<td>' + renderValue(fieldName) + '</td>'
                 + '<td>' + renderValue(lhs) + '</td>'
-                + '<td ' + renderClass(currentResult)+ '>' + renderValue(rhs) + '</td>';
+                + '<td>' + renderValue(rhs) + '</td>';
              + '<tr>';
 
         html += str;

--- a/lib/router.js
+++ b/lib/router.js
@@ -32,7 +32,7 @@ exports.setupAdminRoutes = function () {
     router.post(linz.get('admin forgot password path'), middleware.forgottenPassword.post, routes.forgottenPassword.post);
 
     // map password reset
-    router.get(linz.get('admin password reset path') + '/:id/:hash', middleware.passwordReset.get, routes.passwordReset.get);
+    router.get(linz.get('admin password reset path') + '/:id/:hash', middleware.linz, middleware.passwordReset.get, routes.passwordReset.get);
     router.post(linz.get('admin password reset path'), middleware.passwordReset.post, routes.passwordReset.post);
 
 	router.get('*', middleware.linz, linz.middleware.exclusions(middleware.adminEnsureAuthenticated(), middleware.navigation));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -117,6 +117,28 @@ exports.arrayMatch = function (arr1, arr2) {
 };
 
 /**
+ * Return true if provided arrays contains the same values
+ * @param {Array} arr1
+ * @param {Array} arr2
+ */
+exports.arrayEquals = function (arr1, arr2) {
+
+    // check that arr2 contains every elements in arr1
+    var check1 = arr1.every(function (val) {
+        return arr2.indexOf(val) >= 0;
+    });
+
+    // check that arr1 contains every elements in arr2
+    var check2 = arr2.every(function (val) {
+        return arr1.indexOf(val) >= 0;
+    });
+
+    // compare the result
+    return check1 && check2;
+
+};
+
+/**
  * Escape regex special characters
  * @param {String} str    str with special characters to escape
  * @return {String}

--- a/lib/versions/renderers/cell/document-array.js
+++ b/lib/versions/renderers/cell/document-array.js
@@ -1,74 +1,70 @@
-var cellRenderers = require('./'),
-    async = require('async');
+var async = require('async'),
+    cellRenderers = require('./');
 
 module.exports = function documentArrayRenderer (val, record, fieldName, model, callback) {
 
-    // get form configurations
-    model.schema.tree[fieldName][0].statics.getForm(function (err, form) {
+    // Labels for the embedded field, rather than the model in which the document is embedded.
+    var labels = model.linz.formtools.form[fieldName].linz.formtools.labels,
+        content = '';
 
-        var content = '',
-            tableHeading = [],
-            heading = '';
+    async.eachSeries(record[fieldName], function (field, cb) {
 
-        async.eachSeries(record[fieldName], function (field, cb) {
+        var table = '';
 
-            var table = '';
+        if (field.__parentArray) {
+            // this is a mongoose record, let's convert to object literal
+            field = field.toObject({ virtuals: true});
+        }
 
-            if (field.__parentArray) {
-                // this is a mongoose record, let's convert to object literal
-                field = field.toObject({ virtuals: true});
+        async.eachSeries(Object.keys(field), function (key, fieldValueDone) {
+
+            if (key === '_id' || key === 'id') {
+                return fieldValueDone(null);
             }
 
-            async.eachSeries(Object.keys(field), function (key, fieldValueDone) {
+            table += '<tr><td>' + labels[key] + '</td>';
 
-                if (key === '_id' || key === 'id') {
-                    return fieldValueDone(null);
-                }
+            // mimic the format expected for model
+            var embeddedModel = {
+                schema: model.schema.tree[fieldName][0]
+            };
 
-                table += '<tr><td>' + form[key].label + '</td>';
-
-                // mimic the format expected for model
-                var embeddedModel = {
-                    schema: model.schema.tree[fieldName][0]
-                };
-
-                // render field value
-                cellRenderers.default(field[key], field, key, embeddedModel, function (err, value) {
-
-                    if (err) {
-                        return fieldValueDone(err);
-                    }
-
-                    table += '<td>' + value + '</td></tr>';
-
-                    return fieldValueDone(null);
-
-                });
-
-            }, function (err) {
+            // render field value
+            cellRenderers.default(field[key], field, key, embeddedModel, function (err, value) {
 
                 if (err) {
                     return fieldValueDone(err);
                 }
 
-                // turn content to table
-                table = '<table class="table table-bordered"><tr><th>Field name</th><th>Value</th></tr>' + table + '</table>';
-                content += table;
+                table += '<td>' + value + '</td></tr>';
 
-                return cb(null);
+                return fieldValueDone(null);
 
             });
 
-
         }, function (err) {
 
+
             if (err) {
-                return callback(err);
+                return cb(err);
             }
 
-            return callback(null, content);
+            // turn content to table
+            table = '<table class="table table-bordered"><tr><th>Field name</th><th>Value</th></tr>' + table + '</table>';
+            content += table;
+
+            return cb(null);
 
         });
+
+
+    }, function (err) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        return callback(null, content);
 
     });
 

--- a/lib/versions/templates/compare.html
+++ b/lib/versions/templates/compare.html
@@ -11,15 +11,15 @@
         </div>
         <div class="modal-body">
             {{#ifCond rollback '&&' diffs}}
-            <p>You have requested to rollback to version <strong>{{previous.date}} ({{previous.author}})</strong>. Please review the changes below before confirming the rollback operation.</p>
+            <p>You have requested to rollback to version <strong>{{{previous.date}}} ({{previous.author}})</strong>. Please review the changes below before confirming the rollback operation.</p>
             {{/ifCond}}
             <div class="form-group">
             {{#if diffs}}
                 <table class="table compare-versions">
                     <tr>
                         <th class="fieldName">Field name</th>
-                        <th>{{previous.date}} ({{previous.author}})</th>
-                        <th>{{latest.date}} ({{latest.author}})</th>
+                        <th>{{{previous.date}}} ({{previous.author}})</th>
+                        <th>{{{latest.date}}} ({{latest.author}})</th>
                     </tr>
                     {{{renderDiffs diffs}}}
                 </table>

--- a/lib/versions/templates/overview.html
+++ b/lib/versions/templates/overview.html
@@ -9,24 +9,25 @@
                     <li class="list-group-item">
 
                         <h4>
-                            {{{this.authorLink}}} <small>updated this record on {{this.date}}</small> {{#if @first}} (latest){{/if}}
+                            {{{this.authorLink}}} <small>updated this record on {{{this.date}}}</small> {{#if @first}} (latest){{/if}}
                         </h4>
 
                         {{#unless @first}}
 
                             <div class="btn-group">
                                 <button type="button" class="btn btn-default" data-target="#linzModal" data-linz-control="versions-rollback" data-href="{{./../../adminPath}}/model/{{../../../modelName}}/{{../../../pageId}}/versions-rollback/{{this._id}}/{{../../../versions.0._id}}">Roll back to this version</button>
-        						<button type="button" class="btn btn-default" data-target="#linzModal" data-linz-control="versions-compare-latest" data-href="{{../../adminPath}}/model/{{../../modelName}}/{{../../pageId}}/versions-compare/{{this._id}}/{{../../versions.0._id}}">Compare with latest</button>
+                                <button type="button" class="btn btn-default" data-target="#linzModal" data-linz-control="versions-compare-latest" data-href="{{../../adminPath}}/model/{{../../modelName}}/{{../../pageId}}/versions-compare/{{this._id}}/{{../../versions.0._id}}">Compare with latest</button>
                                 {{#if this.history.length}}
-            						<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-            							<span class="caret"></span>
-            							<span class="sr-only">Toggle Dropdown</span>
-            						</button>
-            						<ul class="dropdown-menu" role="menu">
-            							{{#each this.history}}
-                                            <li><a href="{{../../../../adminPath}}/model/{{../../../../modelName}}/{{../../../../pageId}}/versions-compare/{{this._id}}/{{../_id}}" data-linz-control="versions-compare">{{this.date}} ({{this.author}})</a></li>
+                                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                                        <span class="caret"></span>
+                                        <span class="sr-only">Toggle Dropdown</span>
+                                    </button>
+                                    <ul class="dropdown-menu" role="menu">
+                                        <li class="dropdown-header">Compare with previous versions</li>
+                                        {{#each this.history}}
+                                            <li><a href="{{../../../../adminPath}}/model/{{../../../../modelName}}/{{../../../../pageId}}/versions-compare/{{this._id}}/{{../_id}}" data-linz-control="versions-compare">{{{this.date}}} ({{this.author}})</a></li>
                                         {{/each}}
-            						</ul>
+                                    </ul>
                                 {{/if}}
                             </div>
 
@@ -52,7 +53,26 @@
             var queryObj = $(this),
                 url = queryObj[0].nodeName === 'BUTTON' ? queryObj.attr('data-href') : queryObj.attr('href');
 
-            $('#linzModal').modal().load(url, function () {});
+            // open modal and load URL
+            $('#linzModal').modal().load(url);
+
+            // remove modal shown event
+            $('#linzModal').off('shown.bs.modal');
+
+            // re-bind the shown event
+            $('#linzModal').on('shown.bs.modal', function (e) {
+
+                // convert UTC to local datetime
+                $(this).find('[data-linz-local-date]').each(function () {
+
+                    var dateFormat = $(this).attr('data-linz-date-format') || 'ddd DD/MM/YYYY';
+                    var localDateTime = moment(new Date($(this).attr('data-linz-utc-date'))).format(dateFormat);
+
+                    $(this).html(localDateTime);
+
+                });
+
+            });
 
            return false;
 

--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -61,7 +61,7 @@ module.exports = function  (req, res, next) {
                         return cb(null);
                     }
 
-                    formtoolsAPI.grid.renderFilters(req.params.model, function (err, result) {
+                    formtoolsAPI.grid.renderFilters(req.user, req.params.model, function (err, result) {
 
                         if (err) {
                             return cb(err);
@@ -84,7 +84,7 @@ module.exports = function  (req, res, next) {
                         return cb(null);
                     }
 
-                    formtoolsAPI.grid.getActiveFilters(session.grid.formData.selectedFilters.split(','), session.grid.formData, req.params.model, function (err, result) {
+                    formtoolsAPI.grid.getActiveFilters(req.user, session.grid.formData.selectedFilters.split(','), session.grid.formData, req.params.model, function (err, result) {
 
                         if (err) {
                             return cb(err);
@@ -105,7 +105,7 @@ module.exports = function  (req, res, next) {
                         return cb(null);
                     }
 
-                    formtoolsAPI.grid.renderSearchFilters(session.grid.formData.selectedFilters.split(','), session.grid.formData, req.params.model, function (err, result) {
+                    formtoolsAPI.grid.renderSearchFilters(req.user, session.grid.formData.selectedFilters.split(','), session.grid.formData, req.params.model, function (err, result) {
 
                         if (err) {
                             return cb(err);

--- a/middleware/modelVersionsCompare.js
+++ b/middleware/modelVersionsCompare.js
@@ -1,63 +1,101 @@
-var linz = require('../'),
-    async = require('async'),
+var async = require('async'),
     deep = require('deep-diff'),
     textDiffUtils = require('diff');
+
+function getData (req, cb) {
+
+    var versionsHelpers = require('./_modelVersionsCompare')(req);
+
+    async.series({
+        latest: versionsHelpers.getLastest,
+        previous: versionsHelpers.getPrevious
+    }, cb);
+
+}
 
 module.exports = {
 
     get: function (req, res, next) {
 
-        var versionsHelpers = require('./_modelVersionsCompare')(req, res, next);
+        var versionsHelpers = require('./_modelVersionsCompare')(req);
 
-        async.series({
+        async.waterfall([
 
-            latest: versionsHelpers.getLastest,
-            previous: versionsHelpers.getPrevious
+            (cb) => getData(req, cb),
 
-        }, function (err, result) {
+            (result, cb) => {
 
-            req.linz.diffs = deep.diff(result.previous, result.latest);
-            req.linz.history = {
-                previous: result.previous,
-                latest: result.latest
-            };
+                var diffs = deep.diff(result.previous, result.latest);
 
-            if (!req.linz.diffs) {
-                // there are no change between the 2 versions
-                return next(null);
+                if (!diffs) {
+                    // there are no change between the 2 versions, exit
+                    return cb(null, undefined);
+                }
+
+                // get a list of changed fields and remove duplicates
+                var changedFields = diffs.map(diff => diff.path[0])
+                .filter((fieldName, index, array) =>  array.indexOf(fieldName) == index);
+
+                // get data ready for comparison
+                async.series({
+                    latest: done => versionsHelpers.getVersionById(req.params.revisionBId, changedFields.join(' '), true, done),
+                    previous: done => versionsHelpers.getVersionById(req.params.revisionAId, changedFields.join(' '), true, done)
+                }, cb);
+
+            },
+
+            (result, cb) => {
+
+                if (!result) {
+                    return cb();
+                }
+
+                var form = req.linz.model.linz.formtools.form,
+                    fieldsType = {};
+
+                // populate fieldsType object
+                Object.keys(form).forEach(fieldName => fieldsType[form[fieldName].label] = form[fieldName].type);
+
+                req.linz.diffs = deep.diff(result.previous, result.latest);
+
+                if (!req.linz.diffs) {
+                    // there are no change between the 2 versions, exit
+                    return cb();
+                }
+
+                // generate text diff for properties that are text fields
+                req.linz.diffs.forEach(diff => {
+                    if (diff.kind === 'E' && typeof diff.lhs === 'string' && typeof diff.rhs === 'string' && fieldsType[diff.path[0]] === 'text') {
+                        diff.textDiff = textDiffUtils.diffWords(diff.lhs, diff.rhs);
+                    }
+                });
+
+                req.linz.history = result;
+
+                async.parallel({
+                    latest: versionsHelpers.getLatestVersionAdditionalProps,
+                    previous: versionsHelpers.getPreviousVersionAdditionalProps
+                }, (err, record) => {
+
+                    if (err) {
+                        return cb(err);
+                    }
+
+                    req.linz.history.latest.author = record.latest.author;
+                    req.linz.history.latest.date = record.latest.date;
+                    req.linz.history.latest._id = record.latest._id;
+
+                    req.linz.history.previous.author = record.previous.author;
+                    req.linz.history.previous.date = record.previous.date;
+                    req.linz.history.previous._id = record.previous._id;
+
+                    return cb();
+
+                });
+
             }
 
-            // generate text diff for text field
-            req.linz.diffs.forEach(function (diff) {
-                if (diff.kind === 'E' && typeof diff.lhs === 'string' && typeof diff.rhs === 'string') {
-                    diff.textDiff = textDiffUtils.diffWords(diff.lhs, diff.rhs);
-                }
-            });
-
-            async.parallel({
-
-                latest: versionsHelpers.getLatestVersionAdditionalProps,
-                previous: versionsHelpers.getPreviousVersionAdditionalProps
-
-            }, function (err, record) {
-
-                if (err) {
-                    return next(err);
-                }
-
-                req.linz.history.latest.author = record.latest.author;
-                req.linz.history.latest.date = record.latest.date;
-                req.linz.history.latest._id = record.latest._id;
-
-                req.linz.history.previous.author = record.previous.author;
-                req.linz.history.previous.date = record.previous.date;
-                req.linz.history.previous._id = record.previous._id;
-
-                return next(null);
-
-            });
-
-        });
+        ], next);
 
     }
 

--- a/middleware/modelVersionsCompare.js
+++ b/middleware/modelVersionsCompare.js
@@ -65,7 +65,7 @@ module.exports = {
 
                 // generate text diff for properties that are text fields
                 req.linz.diffs.forEach(diff => {
-                    if (diff.kind === 'E' && typeof diff.lhs === 'string' && typeof diff.rhs === 'string' && fieldsType[diff.path[0]] === 'text') {
+                    if (diff.kind === 'E' && typeof diff.lhs === 'string' && diff.lhs.length && typeof diff.rhs === 'string' && fieldsType[diff.path[0]] === 'text') {
                         diff.textDiff = textDiffUtils.diffWords(diff.lhs, diff.rhs);
                     }
                 });

--- a/middleware/passwordReset.js
+++ b/middleware/passwordReset.js
@@ -58,6 +58,9 @@ module.exports = {
             throw new Error('updatePassword() is not defined for user model.');
         }
 
+        // clear res.clearCookie('linz-return-url') so if use logs in after resetting password, it doesn't redirect back to the password reset page
+        res.clearCookie('linz-return-url');
+
         User.updatePassword(req.body.id, req.body.password, req, res, next);
 
     }

--- a/middleware/recordChange.js
+++ b/middleware/recordChange.js
@@ -35,6 +35,11 @@ module.exports = function (req, res, next) {
 				return;
 			}
 
+			// if transpose is defined for this field, let's tranpose their change so it can compare in the correct format on client side
+			if (form[fieldName].transpose) {
+				theirChange[fieldName] = form[fieldName].transpose(theirChange[fieldName]);
+			}
+
 			switch (form[fieldName].type) {
 
 				case 'number':

--- a/middleware/recordChange.js
+++ b/middleware/recordChange.js
@@ -5,7 +5,7 @@ var linz = require('../'),
 
 module.exports = function (req, res, next) {
 
-	var Model = linz.api.model.get(req.params.model),
+	var Model = req.linz.model,
 		ccSettings = Model.concurrencyControl,
 		formData = req.body,
 		resData = {
@@ -140,8 +140,8 @@ module.exports = function (req, res, next) {
 	});
 
 	// exclude fields that are not editable
-	Object.keys(Model.form).forEach(function (fieldName) {
-		if (Model.form[fieldName].edit && Model.form[fieldName].edit.disabled) {
+	Object.keys(Model.linz.formtools.form).forEach(function (fieldName) {
+		if (Model.linz.formtools.form[fieldName].edit && Model.linz.formtools.form[fieldName].edit.disabled) {
 			exclusionFields[fieldName] = 0;
 		}
 	});
@@ -221,12 +221,12 @@ module.exports = function (req, res, next) {
 			var fieldName = diff.path[0];
 
 			// change fieldname to the related field defined in the relationship
-			if (Model.form[fieldName].relationship) {
-				fieldName = Model.form[fieldName].relationship;
+			if (Model.linz.formtools.form[fieldName].relationship) {
+				fieldName = Model.linz.formtools.form[fieldName].relationship;
 			}
 
 			if (!diffKeys[fieldName]) {
-				diffKeys[fieldName] = Model.form[fieldName].type;
+				diffKeys[fieldName] = Model.linz.formtools.form[fieldName].type;
 			}
 
 		});

--- a/params/model.js
+++ b/params/model.js
@@ -93,7 +93,9 @@ module.exports = function (router) {
 
 				async.forEachOf(form, function (field, key, callback) {
 
-					if (field.type !== 'documentarray') {
+					// if field is not of type documentarray or if it is, it's not implementing the embedded document plugin, exit
+					// if (field.type !== 'documentarray') {
+					if (field.type !== 'documentarray' || !field.schema.statics.getForm) {
 						return callback();
 					}
 

--- a/routes/modelVersionsCompare.js
+++ b/routes/modelVersionsCompare.js
@@ -6,8 +6,8 @@ module.exports = {
 
         var locals = {
                 label: 'Compare versions',
-                latest: req.linz.history.latest,
-                previous: req.linz.history.previous,
+                latest: req.linz.history && req.linz.history.latest ? req.linz.history.latest : undefined,
+                previous: req.linz.history && req.linz.history.previous ? req.linz.history.previous : undefined,
                 diffs: req.linz.diffs
             },
             content = templates.compare(locals);

--- a/views/forgottenPassword.jade
+++ b/views/forgottenPassword.jade
@@ -6,7 +6,6 @@ block content
 		form(role='form', method='post', data-linz-validation='true')
 			if success
 				p A password reset request has been sent to your email at <strong>#{email}</strong>. Please check your email and follow the instructions to update your password.
-				a.btn.btn-primary(href=linz.get('admin path')) Login
 			else
 				.form-group
 					label(for='email') Email address


### PR DESCRIPTION
This PR fixes the following:
- [x] Fix edit page, where it's compulsory to add `embeddedDocument` plugin to any embedded schema for a document. This is no longer a requirement and standard embedded document can be use that doesn't require to be render in the edit page.
- [x] Fix namespace for model form configurations in recordChange middleware.
- [x] Update `linz.api.formtools.grid` function so grid data is retrieved based on a user
- [x] Add `linz.utils.arrayEquals`
- [x] Add a transpose function (similar to transform but works server to client, rather than client to server).
- [x] Fix Reset Password
 - [x] Add `middleware.linz` to reset password route so `req.linz` namespace is available
 - [x] Removed login button from 'Forgotten password' confirmation screen as it's not required
 - [x] Clear `res.clearCookie('linz-return-url') ` so it doesn't redirect back to 'Reset Password' page after successful login
- [x] Refactore data model compare function
 - [x] Should only flag fields that are changed
 - [x] Update text highlighting for compare view. It should only highlight text change for 'Text' fields. This should remove the confusion on what's added and what's removed.
 - [x] Fix incorrect date where it also shows the current date for both records
 - [x] Render date in local date time
 - [x] Update some of the function to ES6 arrow functions
 - [x] Add group heading "Compare with previous versions" for the dropdown list under "Compare with latest" 

__Previous__
![image](https://cloud.githubusercontent.com/assets/3323860/17883280/d1a522e2-6950-11e6-8459-72b38d4a0cf6.png)

__Updated__
![image](https://cloud.githubusercontent.com/assets/3323860/17883290/e4dee032-6950-11e6-9c76-539763e7ba41.png)
