### PR TITLE
Overview action model fix

### DIFF
--- a/routes/recordOverview.js
+++ b/routes/recordOverview.js
@@ -130,7 +130,7 @@ var route = function (req, res, next) {
 
             if (typeof action.modal === 'object') {
                 modal = action.modal;
-                modal.active = true;
+                modal.active = !(modal.active === false); // defaults to true
             } else if (typeof action.modal === 'boolean') {
                 modal.active = action.modal;
             }


### PR DESCRIPTION
This is a quick PR that fixes the overview model action where `modal.active` is always set to true if modal is defined in `overview.actions`.

Now overview will respect `modal.active` value and default it to `true` if it is `undefined`.
