### PR TITLE
Fixes undefined error in modelIndex filter

### DIFF
--- a/views/modelIndex/filter.jade
+++ b/views/modelIndex/filter.jade
@@ -1,5 +1,5 @@
 .form-group
-	label.control-label.filter-name(for='' + ((fieldName) ? fieldName: '') + '')= (( model.grid.activeFilters[fieldName] && model.grid.activeFilters[fieldName].label) ? model.grid.activeFilters[fieldName].label: '')
+	label.control-label.filter-name(for='' + ((fieldName) ? fieldName: '') + '')= ((fieldName) ? (( model.grid.activeFilters[fieldName] && model.grid.activeFilters[fieldName].label) ? model.grid.activeFilters[fieldName].label: '') : '')
 	.filter-control
 		i.fa.fa-times(data-filter-field='' + ((fieldName) ? fieldName: '') + '')
 		!= filterControl


### PR DESCRIPTION
This PR fixes the error `can not read property undefined of undefined` when trying to access `filedName` of `activeFilters` when `filedName` is not defined.

