### PR TITLE
Updated checkbox widget to add hidden element with same name as checkbox

### DIFF
--- a/lib/formtools/widgets/checkboxes.js
+++ b/lib/formtools/widgets/checkboxes.js
@@ -16,6 +16,24 @@ module.exports = function (attrs) {
             },
             elements = [];
 
+        // Add hidden input element with the same name as checkbox
+        // This will make browsers to pass empty value to server on form post when all check boxes are unchecked
+        //
+        // Note 1: When one or more checkboxes are selected, the sever will receive an array of values of selected
+        //         checkboxes as well as an empty string value of the hidden input element that has same name as checkbox
+        //
+        // Note 2: Provide transform function to handle this empty value to checkbox form filed in the project
+        //         that implements Linz
+        var hiddenElm = new formist.Field('input', {
+            attributes: {
+                type: 'hidden',
+                name: name,
+                value: ''
+            }
+        });
+
+        elements.push(hiddenElm);
+
         // add the helpText
         if (field.helpText) {
             o.helpText = {


### PR DESCRIPTION
### Issue: 

 - Value of `undefined` is received in a form post when form field with checkboxes is submitted with all checkboxes unchecked.

 - This means `Save` method will ignore this filed and hence will not be updated.

### Fix

 - `checkbox` widget has been updated to render the `hidden input element` with the same name as checkbox.

 - This will cause browsers to send empty string value set in the `hidden input element` to server in form post.

 - The  `save` method in linz will update the value of checkbox form filed to empty array.


### Usage

 - A project that implements `linz` will have to provide a `transform` method  for a form field to return an `empty array` when no checkboxes are selected as follow:

```transform: function(fieldValue, stage) {

            // make sure we're at the right stage
            if (stage !== 'beforeSave') {
                return fieldValue;
            }

            // if fieldValue is not an array (no checkbox is selected), return an empty array
            if (!Array.isArray(fieldValue)) {
                return [];
            }

            // filter out all falsy values
            var values = fieldValue.filter( function(value) {
                return !!value;
            });

            return values;

        }```

