### PR TITLE
Columns rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### BREAKING CHANGES
 
-- Search and replaced `Grid` with `List`. You will need to change all your models to use `list` rather than `grid` now.
-- Search and replace `Columns` with `Fields`.
+- Search and replaced `Grid` with `List`. You will need to update all your models to use `list` rather than `grid` now.
+- Search and replaced `Columns` with `Fields`. You will need to update all your models to use `fields` rather than `columns` now.
 
 ## v0.7.0.0 (3 March 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### BREAKING CHANGES
 
 - Search and replaced `Grid` with `List`. You will need to change all your models to use `list` rather than `grid` now.
+- Search and replace `Columns` with `Fields`.
 
 ## v0.7.0.0 (3 March 2017)
 

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -139,7 +139,7 @@ module.exports = function formtoolsPlugin (schema, options) {
 
     };
 
-    // setup a method to retrieve the column list
+    // setup a method to retrieve the field list
     schema.statics.getList = function (user, cb) {
 
         // if list is defined, that means it was provided as an object DSL, let's return the formatted version
@@ -183,7 +183,7 @@ module.exports = function formtoolsPlugin (schema, options) {
 
     };
 
-    // setup a method to retrieve the column list
+    // setup a method to retrieve the field list
     schema.statics.getOverview = function (user, cb) {
 
         // if overview is defined, that means it was provided as an object DSL, let's return the formatted version

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -70,8 +70,8 @@ var listDefaults = function (list, labels) {
 
     list.sortBy = transformSortBy(labels, list.sortBy || ['dateModified']);
 
-    // define a default set of columns
-    list.columns = columnsDefaults(list.columns, labels) || {
+    // define a default set of fields
+    list.fields = fieldsDefaults(list.fields, labels) || {
         title: {
             label: 'Label',
             renderer: linz.formtools.cellRenderers.overviewLink
@@ -108,58 +108,58 @@ var listDefaults = function (list, labels) {
 
 };
 
-// a function ensure the columns object has the properties we're expecting
-var columnsDefaults = function (columns, labels) {
+// a function ensure the fields object has the properties we're expecting
+var fieldsDefaults = function (fields, labels) {
 
     // if it's undefined, don't do anything, return an undefined value
     // and the || operator in defaults will set a value
-    if (columns === undefined) return columns;
+    if (fields === undefined) return fields;
 
-    // loop through the columns and make sure they have the correct setup, i.e. label & renderer
-    Object.keys(columns).forEach(function (column) {
+    // loop through the fields and make sure they have the correct setup, i.e. label & renderer
+    Object.keys(fields).forEach(function (field) {
 
         // match a simple string, i.e. Label
-        if (typeof columns[column] === 'string') {
+        if (typeof fields[field] === 'string') {
 
-            columns[column] = {
-                label: columns[column]
+            fields[field] = {
+                label: fields[field]
             };
 
         }
 
-        if (typeof columns[column] === 'boolean' && columns[column] === true) {
+        if (typeof fields[field] === 'boolean' && fields[field] === true) {
 
-            columns[column] = {
-                label: labels[column]
+            fields[field] = {
+                label: labels[field]
             };
 
         }
 
         // make sure the label exists
-        if (!columns[column].label) {
-            columns[column].label = labels[column];
+        if (!fields[field].label) {
+            fields[field].label = labels[field];
         }
 
-        if (columns[column].virtual && !columns[column].renderer) {
+        if (fields[field].virtual && !fields[field].renderer) {
 
-            throw new Error('Renderer attribute is missing for virtual column options.list.columns.' + column);
+            throw new Error('Renderer attribute is missing for virtual field options.list.fields.' + field);
 
         }
 
-        if ((column === 'title' || column === 'label') && !columns[column].renderer) {
+        if ((field === 'title' || field === 'label') && !fields[field].renderer) {
 
-            columns[column].renderer = linz.formtools.cellRenderers.overviewLink;
+            fields[field].renderer = linz.formtools.cellRenderers.overviewLink;
 
         } else {
 
             // default the renderer
-            columns[column].renderer = columns[column].renderer || linz.formtools.cellRenderers.default;
+            fields[field].renderer = fields[field].renderer || linz.formtools.cellRenderers.default;
 
         }
 
     });
 
-    return columns;
+    return fields;
 
 };
 
@@ -207,7 +207,7 @@ var overviewDefaults = function (overview) {
 
 };
 
-// a function ensure the columns object has the properties we're expecting
+// a function ensure the fields object has the properties we're expecting
 var filtersDefault = function (filters, labels) {
 
     // if it's undefined, don't do anything, return an undefined value
@@ -531,7 +531,7 @@ var indexObj = function (fieldName) {
 module.exports = {
     defaults: defaults,
     listDefaults: listDefaults,
-    columnsDefaults: columnsDefaults,
+    fieldsDefaults: fieldsDefaults,
     filtersDefault: filtersDefault,
     formSettings: formSettings,
     formConfigDefault: formConfigDefault,

--- a/middleware/configList.js
+++ b/middleware/configList.js
@@ -11,7 +11,7 @@ module.exports = function () {
 
         // construct the list object
         req.linz.configList = {
-            columns: {
+            fields: {
                 label: {
                     label: 'Label',
                     renderer: linz.formtools.cellRenderers.overviewLink
@@ -87,19 +87,19 @@ module.exports = function () {
                 // loop through each record
                 async.each(records, function (record, recordDone) {
 
-                    // loop through each column
-                    async.each(Object.keys(req.linz.configList.columns), function (column, columnDone) {
+                    // loop through each field
+                    async.each(Object.keys(req.linz.configList.fields), function (field, fieldDone) {
 
-                        req.linz.configList.columns[column].renderer(record[column], record, column, req.linz.configs[record._id], function (err, value) {
+                        req.linz.configList.fields[field].renderer(record[field], record, field, req.linz.configs[record._id], function (err, value) {
 
                             if (err) {
-                                return columnDone(err, records);
+                                return fieldDone(err, records);
                             }
 
                             var index = records.indexOf(record);
-                            records[index][column] = value;
+                            records[index][field] = value;
 
-                            return columnDone(null, records);
+                            return fieldDone(null, records);
 
                         });
 

--- a/routes/configList.js
+++ b/routes/configList.js
@@ -4,23 +4,23 @@ var linz = require('../'),
 /* GET /admin/configs/list */
 var route = function (req, res) {
 
-	// determine if we need to render the actions column
+	// determine if we need to render the actions field
 	async.some(req.linz.records, function (record, cb) {
 
-		// if any of these records can edit or reset, we should show the column
+		// if any of these records can edit or reset, we should show the field
 		if (record.permissions.canEdit !== false || record.permissions.canReset !== false) {
 			return cb(true);
 		}
 
 		return cb(false);
 
-	}, function (renderActionsColumn) {
+	}, function (renderActionsField) {
 
 		res.render(linz.api.views.viewPath('configList.jade'), {
 			list: req.linz.configList,
 			configs: req.linz.configs,
 			records: req.linz.records,
-			renderActionsColumn: renderActionsColumn
+			renderActionsField: renderActionsField
 		});
 
 	});

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -393,7 +393,7 @@ describe('formtools', function () {
 
             OverridesPostSchema.plugin(formtools.plugins.document, {
                 list: {
-                    columns: {
+                    fields: {
                         title: 'Label',
                         firstName: {
                             label: 'Name',
@@ -625,42 +625,42 @@ describe('formtools', function () {
 
         describe('list', function () {
 
-            describe('columns', function () {
+            describe('fields', function () {
 
-                describe('with columns defaults', function () {
+                describe('with fields defaults', function () {
 
                     it('should have a title', function () {
-                        listOpts.columns.title.should.be.an.instanceOf(Object).and.have.property('label', 'Label');
+                        listOpts.fields.title.should.be.an.instanceOf(Object).and.have.property('label', 'Label');
                     });
 
                     it('should have a overview link renderer for title', function () {
-                        listOpts.columns.title.should.be.an.instanceOf(Object).and.have.property('renderer', linz.formtools.cellRenderers.overviewLink);
+                        listOpts.fields.title.should.be.an.instanceOf(Object).and.have.property('renderer', linz.formtools.cellRenderers.overviewLink);
                     });
 
                     it('should have a created date', function () {
-                        listOpts.columns.dateCreated.should.be.an.instanceOf(Object).and.have.property('label', 'Date created');
+                        listOpts.fields.dateCreated.should.be.an.instanceOf(Object).and.have.property('label', 'Date created');
                     });
 
                     it('should have a link renderer for created date', function () {
-                        listOpts.columns.dateCreated.should.be.an.instanceOf(Object).and.have.property('renderer', linz.formtools.cellRenderers.date);
+                        listOpts.fields.dateCreated.should.be.an.instanceOf(Object).and.have.property('renderer', linz.formtools.cellRenderers.date);
                     });
 
-                }); // end describe('columns defaults')
+                }); // end describe('fields defaults')
 
-                describe("allowing column overrides", function () {
+                describe("allowing field overrides", function () {
 
                     it('should set custom fields', function () {
-                        overridesListOpts.columns.firstName.should.have.property({
+                        overridesListOpts.fields.firstName.should.have.property({
                             label: 'Name',
                             renderer: linz.formtools.cellRenderers.overviewLink
                         });
                     });
 
                     it('should default to overview link rendered for title, if renderer is not provided', function () {
-                        overridesListOpts.columns.title.renderer.name.should.equal('overviewLinkRenderer');
+                        overridesListOpts.fields.title.renderer.name.should.equal('overviewLinkRenderer');
                     });
 
-                }); // end describe('column overrides')
+                }); // end describe('field overrides')
 
                 describe("using cell renderer", function () {
 
@@ -758,7 +758,7 @@ describe('formtools', function () {
 
                 });
 
-            })// end describe('columns')
+            })// end describe('fields')
 
             describe('actions', function () {
 
@@ -989,14 +989,14 @@ describe('formtools', function () {
 
             }); // end describe('sorting')
 
-            describe('virtual columns',function () {
+            describe('virtual fields',function () {
 
-                it('should assign custom cell renderer for virtual column', function () {
-                    overridesListOpts.columns.sendWelcomeEmail.renderer.name.should.equal('sendWelcomeEmailRenderer');
+                it('should assign custom cell renderer for virtual field', function () {
+                    overridesListOpts.fields.sendWelcomeEmail.renderer.name.should.equal('sendWelcomeEmailRenderer');
                 });
 
-                it('should execute custom cell renderer for virtual column', function (done) {
-                    overridesListOpts.columns.sendWelcomeEmail.renderer({}, 'sendWelcomeEmail', 'mmsUser', function (err, value) {
+                it('should execute custom cell renderer for virtual field', function (done) {
+                    overridesListOpts.fields.sendWelcomeEmail.renderer({}, 'sendWelcomeEmail', 'mmsUser', function (err, value) {
 
                         if (err) {
                             throw err;
@@ -1009,12 +1009,12 @@ describe('formtools', function () {
                     });
                 });
 
-                it('should throw an error if custom renderer is not provided for virtual column', function () {
+                it('should throw an error if custom renderer is not provided for virtual field', function () {
 
-                    var ErrorVirtualColumnsSchema,
-                        ErrorVirtualColumnsModel;
+                    var ErrorVirtualFieldsSchema,
+                        ErrorVirtualFieldsModel;
 
-                    ErrorVirtualColumnsSchema = new mongoose.Schema({
+                    ErrorVirtualFieldsSchema = new mongoose.Schema({
                         firstName: String,
                         lastName: String,
                         username: String,
@@ -1029,9 +1029,9 @@ describe('formtools', function () {
 
                     try {
 
-                        ErrorVirtualColumnsSchema.plugin(formtools.plugins.document, {
+                        ErrorVirtualFieldsSchema.plugin(formtools.plugins.document, {
                             list: {
-                                columns: {
+                                fields: {
                                     title: 'Label',
                                     firstName: {
                                         label: 'Name',
@@ -1086,13 +1086,13 @@ describe('formtools', function () {
 
                     } catch (e) {
 
-                        e.message.should.equal('Renderer attribute is missing for virtual column options.list.columns.sendWelcomeEmail');
+                        e.message.should.equal('Renderer attribute is missing for virtual field options.list.fields.sendWelcomeEmail');
 
                     }
 
                 });
 
-            }); // end describe('virtual columns')
+            }); // end describe('virtual fields')
 
             describe('filters', function () {
 

--- a/views/configList.jade
+++ b/views/configList.jade
@@ -13,16 +13,16 @@ block content
 							thead
 								tr
 									th #
-									if renderActionsColumn
+									if renderActionsField
 										th Actions
-									for column in list.columns
-										th= column.label
+									for field in list.fields
+										th= field.label
 							tbody
 								for record, index in records
 									if record.permissions.canList !== false
 										tr
 											td= index+1
-											if renderActionsColumn
+											if renderActionsField
 												td
 													div.btn-group
 														if record.permissions.canEdit !== false
@@ -31,7 +31,7 @@ block content
 														if record.permissions.canReset !== false
 															a.btn.btn-default(href='' + linz.api.url.getAdminLink(configs[Object.keys(configs)[0]], 'default', record._id), data-linz-control="config-default")
 																span(class="glyphicon glyphicon-refresh")
-											each val in Object.keys(list.columns)
+											each val in Object.keys(list.fields)
 												td!= record[val]
 
 block script

--- a/views/modelIndex/records.jade
+++ b/views/modelIndex/records.jade
@@ -8,8 +8,8 @@ if records.length > 0
 							input(type="checkbox", data-linz-control="checked-all")
 						if permissions.canDelete !== false || permissions.canEdit !== false || model.list.recordActions.length
 							th.actions Actions
-						for column in model.list.columns
-							th= column.label
+						for field in model.list.fields
+							th= field.label
 				tbody
 					for record, index in records
 						tr
@@ -53,5 +53,5 @@ if records.length > 0
 																else
 																	a(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target data-linz-modal=action.modal.active data-linz-modal-callback=action.modal.callback)= action.label
 
-							each val in Object.keys(model.list.columns)
+							each val in Object.keys(model.list.fields)
 								td!= record['rendered'][val]


### PR DESCRIPTION
This PR renames all mentions of columns to fields.

## Setup

- [x] Make sure your project is using a local version of Linz.
- [x] In your project models, rename `columns` to `fields`.

## Related PRs

- PR #114

## Testing

- [x] Click around the admin interface, everything should be the same.