### PR TITLE
Modal record action

### DIFF
--- a/docs/models_list.rst
+++ b/docs/models_list.rst
@@ -30,7 +30,7 @@ list.actions
 
 - ``label`` is the name of the action.
 - ``action`` is the last portion of a URL, which is used to perform the action.
-- ``useModal`` optionally render the results in a modal view.
+- ``modal`` optionally render the results in a modal view.
 
 For example::
 
@@ -38,7 +38,7 @@ For example::
     {
       label: 'Import people',
       action: 'import-from-csv',
-      useModal: true
+      modal: true
     }
   ]
 

--- a/docs/models_list.rst
+++ b/docs/models_list.rst
@@ -30,13 +30,15 @@ list.actions
 
 - ``label`` is the name of the action.
 - ``action`` is the last portion of a URL, which is used to perform the action.
+- ``useModal`` optionally render the results in a modal view.
 
 For example::
 
   actions: [
     {
       label: 'Import people',
-      action: 'import-from-csv'
+      action: 'import-from-csv',
+      useModal: true
     }
   ]
 

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -182,8 +182,10 @@ var actionsDefaults = function (actions) {
         return actions;
     }
 
-    // loop through each of the actions, and update the url
-    actions.forEach(function (action) {
+    // only apply this alteration once
+    actions.filter(function (action) {
+        return action.action.substr(0, 7) !== 'action/';
+    }).forEach(function (action) {
         action.action = 'action/' + action.action;
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-8.0.0",
+  "version": "1.0.0-8.1.0",
   "description": "Node.js administration interface framework",
   "main": "linz.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-8.1.0",
+  "version": "1.0.0-8.0.0",
   "description": "Node.js administration interface framework",
   "main": "linz.js",
   "scripts": {

--- a/public/js/model/index.js
+++ b/public/js/model/index.js
@@ -166,6 +166,18 @@
        return false;
     });
 
+    // bind record action buttons
+    $('[data-linz-control="record-action"]').click(function () {
+
+        var queryObj = $(this),
+            url = queryObj.attr('href');
+
+        $('#recordActionModal').modal().find('.modal-dialog').load(url, function () {});
+
+       return false;
+
+    });
+
     // bind model save button and update the selected ids to modal form
     $('#groupActionModal').on('shown.bs.modal', function (e) {
 

--- a/public/js/model/index.js
+++ b/public/js/model/index.js
@@ -196,6 +196,16 @@
 
     });
 
+    // bind model save button
+    $('#recordActionModal').on('shown.bs.modal', function (e) {
+
+        var _this = this;
+
+        // add form validation
+        $(_this).find('form[data-linz-validation="true"]').bootstrapValidator({});
+
+    });
+
     // bind export button
     $('[data-linz-control="export"]').click(function (event) {
 

--- a/public/js/model/index.js
+++ b/public/js/model/index.js
@@ -161,7 +161,7 @@
         var queryObj = $(this),
             url = queryObj.attr('href');
 
-        $('#groupActionModal').modal().find('.modal-dialog').load(url, function () {});
+        $('#groupActionModal').modal().find('.modal-content').load(url, function () {});
 
        return false;
     });
@@ -172,7 +172,7 @@
         var queryObj = $(this),
             url = queryObj.attr('href');
 
-        $('#recordActionModal').modal().find('.modal-dialog').load(url, function () {});
+        $('#recordActionModal').modal().find('.modal-content').load(url, function () {});
 
        return false;
 
@@ -217,7 +217,7 @@
             useModal = (queryObj.attr('data-target') === "#exportModal");
 
         if (useModal) {
-            $('#exportModal').modal().find('.modal-dialog').load(url, function () {});
+            $('#exportModal').modal().find('.modal-content').load(url, function () {});
             return false;
         }
 

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -134,7 +134,7 @@ if (!linz) {
             var url = button[0].nodeName === 'BUTTON' ? button.attr('data-href') : button.attr('href');
 
             // open modal and load URL
-            $('#linzModal').modal().find('.modal-dialog').load(url);
+            $('#linzModal').modal().find('.modal-content').load(url);
 
             // remove modal shown event
             $('#linzModal').off('shown.bs.modal');

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -134,7 +134,7 @@ if (!linz) {
             var url = button[0].nodeName === 'BUTTON' ? button.attr('data-href') : button.attr('href');
 
             // open modal and load URL
-            $('#linzModal').modal().load(url);
+            $('#linzModal').modal().find('.modal-dialog').load(url);
 
             // remove modal shown event
             $('#linzModal').off('shown.bs.modal');

--- a/routes/modelIndex.js
+++ b/routes/modelIndex.js
@@ -77,7 +77,8 @@ var route = function (req, res, next) {
             singular: inflection.humanize(req.linz.model.linz.formtools.model.label, true),
             plural: req.linz.model.linz.formtools.model.plural
         },
-        modelQuery: JSON.stringify(req.linz.model.formData)
+        modelQuery: JSON.stringify(req.linz.model.formData),
+        user: req.user
     };
 
     const renderRecordAction = data.model.list.recordActions.renderer || recordActionRenderers.defaultRenderer;

--- a/routes/recordOverview.js
+++ b/routes/recordOverview.js
@@ -12,7 +12,8 @@ var route = function (req, res, next) {
         record: clone(req.linz.record.toObject({ virtuals: true})),
         permissions: req.linz.model.linz.formtools.permissions,
         formtools: req.linz.model.linz.formtools,
-        overview: req.linz.overview
+        overview: req.linz.overview,
+        user: req.user
     };
 
     if (Array.isArray(locals.overview.body)) {

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -63,6 +63,7 @@ html(lang="en")&attributes(attributes)
 
 		.modal.fade.modal-linz#linzModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
 			.modal-dialog
+				.modal-content
 
 		if (env === 'development')
 			script(src='' + linz.get('admin path') + '/public/js/jquery.min.js')

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -62,6 +62,7 @@ html(lang="en")&attributes(attributes)
 				block content
 
 		.modal.fade.modal-linz#linzModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
+			.modal-dialog
 
 		if (env === 'development')
 			script(src='' + linz.get('admin path') + '/public/js/jquery.min.js')

--- a/views/modelIndex.jade
+++ b/views/modelIndex.jade
@@ -15,10 +15,12 @@ block content
                             include modelIndex/paging
 
             if records.length > 0
-                if (typeof records.template === 'string')
+                block main-content
                     != records.template
 
         .modal.fade.modal-linz#groupActionModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
+            .modal-dialog
+        .modal.fade.modal-linz#recordActionModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
             .modal-dialog
         .modal.fade.modal-linz#exportModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
             .modal-dialog

--- a/views/modelIndex.jade
+++ b/views/modelIndex.jade
@@ -20,10 +20,13 @@ block content
 
         .modal.fade.modal-linz#groupActionModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
             .modal-dialog
+                .modal-content
         .modal.fade.modal-linz#recordActionModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
             .modal-dialog
+                .modal-content
         .modal.fade.modal-linz#exportModal(tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true")
             .modal-dialog
+                .modal-content
         div#modelQuery.hidden!= modelQuery
 
 block script

--- a/views/partials/action-record.jade
+++ b/views/partials/action-record.jade
@@ -1,34 +1,38 @@
 div.btn-group
 
-	if permissions.canEdit !== false
-		if record.edit && record.edit.disabled
-			a.btn.btn-default(href='', data-linz-control="edit", data-linz-disabled='true', data-linz-disabled-message=record.edit.message)
-				span(class="glyphicon glyphicon-pencil")
-		else
-			a.btn.btn-default(href=linz.api.url.getAdminLink(model, 'edit', record._id), data-linz-control="edit")
-				span(class="glyphicon glyphicon-pencil")
+    if permissions.canEdit !== false
+        if record.edit && record.edit.disabled
+            a.btn.btn-default(href='', data-linz-control="edit", data-linz-disabled='true', data-linz-disabled-message=record.edit.message)
+                span(class="glyphicon glyphicon-pencil")
+        else
+            a.btn.btn-default(href=linz.api.url.getAdminLink(model, 'edit', record._id), data-linz-control="edit")
+                span(class="glyphicon glyphicon-pencil")
 
-	if permissions.canDelete !== false
-		if record.delete && record.delete.disabled
-			a.btn.btn-default(href='', data-linz-control="delete", data-linz-disabled='true', data-linz-disabled-message=record.delete.message)
-				span(class="glyphicon glyphicon-trash")
-		else
-			a.btn.btn-default(href=linz.api.url.getAdminLink(model, 'delete', record._id), data-linz-control="delete")
-				span(class="glyphicon glyphicon-trash")
+    if permissions.canDelete !== false
+        if record.delete && record.delete.disabled
+            a.btn.btn-default(href='', data-linz-control="delete", data-linz-disabled='true', data-linz-disabled-message=record.delete.message)
+                span(class="glyphicon glyphicon-trash")
+        else
+            a.btn.btn-default(href=linz.api.url.getAdminLink(model, 'delete', record._id), data-linz-control="delete")
+                span(class="glyphicon glyphicon-trash")
 
-	if model.list.recordActions.length
-		div.btn-group
-			button.btn.btn-default.dropdown-toggle(type="button", data-toggle="dropdown")
-				span.caret
-			ul.dropdown-menu(role="menu")
-				for action in model.list.recordActions
-					li(role='presentation')
-						if action.type === 'header'
-							li(role='presentation', class='dropdown-header')= action.label
-						else if action.type === 'divider'
-							li(role='presentation', class='divider')
-						else
-							if (record.recordActions && record.recordActions[action.label] && record.recordActions[action.label].disabled)
-								a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message)= action.label
-							else
-								a(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target data-linz-modal=action.modal.active data-linz-modal-callback=action.modal.callback)= action.label
+    if model.list.recordActions.length
+        div.btn-group
+            button.btn.btn-default.dropdown-toggle(type="button", data-toggle="dropdown")
+                span.caret
+            ul.dropdown-menu(role="menu")
+                for action in model.list.recordActions
+                    li(role='presentation')
+                        if action.type === 'header'
+                            li(role='presentation', class='dropdown-header')= action.label
+                        else if action.type === 'divider'
+                            li(role='presentation', class='divider')
+                        else
+                            if (record.recordActions && record.recordActions[action.label] && record.recordActions[action.label].disabled)
+                                a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message)= action.label
+                            else
+                                - action.attributes = action.attributes || {}
+                                if action.useModal
+                                    - action.attributes['data-linz-control'] = 'record-action'
+                                    - action.attributes['data-target'] = '#recordActionModal'
+                                a(role='menuitem' tabindex='-1' href=linz.api.url.getAdminLink(model, action.action, record._id))&attributes(action.attributes)= action.label

--- a/views/partials/action-record.jade
+++ b/views/partials/action-record.jade
@@ -32,7 +32,7 @@ div.btn-group
                                 a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message)= action.label
                             else
                                 - action.attributes = action.attributes || {}
-                                if action.useModal
+                                if action.modal
                                     - action.attributes['data-linz-control'] = 'record-action'
                                     - action.attributes['data-target'] = '#recordActionModal'
                                 a(role='menuitem' tabindex='-1' href=linz.api.url.getAdminLink(model, action.action, record._id))&attributes(action.attributes)= action.label

--- a/views/recordOverview.jade
+++ b/views/recordOverview.jade
@@ -1,58 +1,61 @@
 extends layout
 
 block header
-	.model-title
-		h1= record.title
-	.model-actions
-		if permissions.canEdit !== false || permissions.canDelete !== false
-			.actions
-				if permissions.canEdit !== false
-					span.edit
-						a.btn.btn-primary(href='' + linz.api.url.getAdminLink(model, 'edit', record._id), data-linz-control="edit", data-linz-disabled=((record.edit && record.edit.disabled) ? 'true' : false), data-linz-disabled-message=((record.edit && record.edit.disabled) ? record.edit.message : false))
-							i.fa.fa-edit
-							| Edit
-				if permissions.canDelete !== false
-					span.delete
-						a.btn.btn-default(href='' + linz.api.url.getAdminLink(model, 'delete', record._id), data-linz-control="delete", data-linz-disabled=((record.delete && record.delete.disabled) ? 'true' : false), data-linz-disabled-message=((record.delete && record.delete.disabled) ? record.delete.message : false))
-							i.fa.fa-trash-o
-							| Delete
+    .model-title
+        h1= record.title
+    .model-actions
+        if permissions.canEdit !== false || permissions.canDelete !== false
+            .actions
+                if permissions.canEdit !== false
+                    span.edit
+                        a.btn.btn-primary(href='' + linz.api.url.getAdminLink(model, 'edit', record._id), data-linz-control="edit", data-linz-disabled=((record.edit && record.edit.disabled) ? 'true' : false), data-linz-disabled-message=((record.edit && record.edit.disabled) ? record.edit.message : false))
+                            i.fa.fa-edit
+                            | Edit
+                if permissions.canDelete !== false
+                    span.delete
+                        a.btn.btn-default(href='' + linz.api.url.getAdminLink(model, 'delete', record._id), data-linz-control="delete", data-linz-disabled=((record.delete && record.delete.disabled) ? 'true' : false), data-linz-disabled-message=((record.delete && record.delete.disabled) ? record.delete.message : false))
+                            i.fa.fa-trash-o
+                            | Delete
 
-		if formtools.overview.actions && formtools.overview.actions.length
-			.custom-actions
-				if formtools.overview.actions.length === 1
-					for action in formtools.overview.actions
-						a.btn.btn-default(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target data-linz-modal=action.modal.active data-linz-modal-callback=action.modal.callback)= action.label				
-				else
-					.dropdown
-						button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown')
-							| Actions&nbsp;
-							span.caret
-						ul.dropdown-menu(role='menu')
-							for action in formtools.overview.actions
-								if action.type === 'header'
-									li(role='presentation', class='dropdown-header')= action.label
-								else if action.type === 'divider'
-									li(role='presentation', class='divider')
-								else
-									li(role='presentation')
-										if action.isDisabled
-											a(role='menuitem', tabindex='-1', href='', data-linz-disabled='true', data-linz-disabled-message=action.disabledMessage)= action.label
-										else
-											a(role='menuitem', tabindex='-1', href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target data-linz-modal=action.modal.active data-linz-modal-callback=action.modal.callback)= action.label
-		if permissions.canList !== false
-			.actions
-				span.back
-					a.btn.btn-default(href='' + linz.api.url.getAdminLink(model))
-						i.fa.fa-chevron-left
-						| View all #{formtools.model.plural}
+        if formtools.overview.actions && formtools.overview.actions.length
+            .custom-actions
+                if formtools.overview.actions.length === 1
+                    for action in formtools.overview.actions
+                        a.btn.btn-default(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target data-linz-modal=action.modal.active data-linz-modal-callback=action.modal.callback)= action.label
+                else
+                    .dropdown
+                        button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown')
+                            | Actions&nbsp;
+                            span.caret
+                        ul.dropdown-menu(role='menu')
+                            for action in formtools.overview.actions
+                                if action.type === 'header'
+                                    li(role='presentation', class='dropdown-header')= action.label
+                                else if action.type === 'divider'
+                                    li(role='presentation', class='divider')
+                                else
+                                    li(role='presentation')
+                                        if action.isDisabled
+                                            a(role='menuitem', tabindex='-1', href='', data-linz-disabled='true', data-linz-disabled-message=action.disabledMessage)= action.label
+                                        else
+                                            a(role='menuitem', tabindex='-1', href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target data-linz-modal=action.modal.active data-linz-modal-callback=action.modal.callback)= action.label
+        if permissions.canList !== false
+            .actions
+                span.back
+                    a.btn.btn-default(href='' + linz.api.url.getAdminLink(model))
+                        i.fa.fa-chevron-left
+                        | View all #{formtools.model.plural}
 
 block content
-	.container.linz-container.overview.config
-		.pane
-			.body
-				.overview-body
-					if overview.body
-						include overview/body
-				if overview.versions
-					.overview-versions
-						div!= overview.versions
+    .container.linz-container.overview.config
+        .pane
+            .body
+                .overview-body
+                    if overview.body
+                        include overview/body
+                if overview.versions
+                    .overview-versions
+                        div!= overview.versions
+
+block script
+    script(src='' + linz.get('admin path') + '/public/js/model/index.js')


### PR DESCRIPTION
This PR adds a modal option to record-actions that is currently available with group-actions.

## Setup

- You will need an existing record action.
- You will need the associated views in your project.

## Related PRs

- None.

## Testing

- [x] With an existing record action, add the `modal: true` property.
- [x] Trigger the action and check that the modal correctly renders (This is dependant on the view so if anything pops up it should be working).
