### PR TITLE
Document fix

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Expected behaviour
+
+
+
+### Actual behaviour
+
+
+
+### Steps to reproduce the behaviour
+
+  1.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Fixes # .
+
+### Setup
+
+  - [ ] A list of steps to get started with testing.
+
+### Testing
+
+  - [ ] All the steps required to complete testing the PR.
+
+### Notes
+
+  - Any additional notes you think will be useful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.0.0-8.0.1 (11 April 2017)
+## Unreleased
 
 - Fixes a bug when trying to wrap the list DSL with a `(user, callback)` function.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.0-8.0.1 (11 April 2017)
+
+- Fixes a bug when trying to wrap the list DSL with a `(user, callback)` function.
+
 ## v1.0.0-8.0.0 (27 March 2017)
 
 ### BREAKING CHANGES

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -83,11 +83,11 @@ module.exports = function formtoolsPlugin (schema, options) {
     }
 
     // Automatically add some indexes.
-    if (list.sortBy) {
+    if (list && list.sortBy) {
         indexes = list.sortBy.map(sort => sort.field);
     }
 
-    if (list.filters) {
+    if (list && list.filters) {
         indexes = indexes.concat(Object.keys(list.filters));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-8.0.1",
+  "version": "1.0.0-8.0.0",
   "description": "Node.js administration interface framework",
   "main": "linz.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-8.0.0",
+  "version": "1.0.0-8.0.1",
   "description": "Node.js administration interface framework",
   "main": "linz.js",
   "scripts": {


### PR DESCRIPTION
Prevents an indexing bug when trying to wrap `list` in a `(user, callback)` function.

### Setup

  - [ ] Add something like this to your list model:
```
module.exports = (user, callback) => {

    return callback(null, {
        fields: ...,
        filters: ...,
        export: ...,
        sortBy: ...,
        renderer: linz.formtools.listRenderers.list
    });

};
```

### Testing

  - [x] There should be no visible changes.

### Notes

  - As a bonus, I have also added some basic Github templates :).