### PR TITLE
Fix modal record actions

### DIFF
--- a/views/partials/action-record.jade
+++ b/views/partials/action-record.jade
@@ -32,7 +32,7 @@ div.btn-group
                                 a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message)= action.label
                             else
                                 - action.attributes = action.attributes || {}
-                                if action.modal
+                                if action.modal.active
                                     - action.attributes['data-linz-control'] = 'record-action'
                                     - action.attributes['data-target'] = '#recordActionModal'
                                 a(role='menuitem' tabindex='-1' href=linz.api.url.getAdminLink(model, action.action, record._id))&attributes(action.attributes)= action.label


### PR DESCRIPTION
It seems `action.modal` is always present. `action.modal.active` is the boolean that controls whether a user has set `modal: true`