### PR TITLE
Linz's init method now expects an options object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - All modal containers now contain the `div.modal-dialog > div.modal-content` structure.
 - Record actions now support `modal: true` to have the URL content displayed within a modal.
 - Fixed issue in which action URLs are sometimes updated twice and then no longer function correctly.
+- Rather than supplying Mongoose, Express, Passport and an options object as arguments to Linz's init function (in any order), Linz now expects an object. The object can have `mongoose`, `express`, `passport` and `options` keys as required.
 
 ## v1.0.0-8.0.0 (27 March 2017)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,12 +26,12 @@ When you require Linz, you're returned a singleton. This has the advantage that 
 Initialization
 ==============
 
-Linz must be initialized. During initialization, Linz can optionally accept any of the following (in any order):
+Linz must be initialized. During initialization, Linz accepts an options object with any of the following optional keys:
 
-- An initialized Express intance.
-- An initialized Passport instance.
-- An initialized Mongoose instance.
-- An options object to customise Linz.
+- ``express``: An initialized Express intance.
+- ``passport``: An initialized Passport instance.
+- ``mongoose``: An initialized Mongoose instance.
+- ``options``: An options object to customise Linz.
 
 For example::
 
@@ -40,17 +40,24 @@ For example::
       passport = require('passport'),
       linz = require('linz');
 
-  linz.init(express(), mongoose, passport, {
-    'load configs': false
+  linz.init({
+      express: express(),
+      mongoose: mongoose
+      passport: passport,
+      options: {
+          'load configs': false
+      }
   });
 
-If neither an initialized instance of Express, Passport or Mongoose, nor an options object have been passed, Linz will create them:
+If neither an initialized instance of Express, Passport or Mongoose, nor an options object have been passed, Linz will create them for you::
 
-  // use anything that is passed in
-  _app = _app || express();
-  _mongoose = _mongoose || require('mongoose');
-  _passport = _passport || require('passport');
-  _options = _options || {};
+  // Use anything that has been passed through, or default it as required.
+  this.app = opts.express || express();
+  this.mongoose = opts.mongoose || require('mongoose');
+  this.passport = opts.passport || require('passport');
+
+  // overlay runtime options, these will override linz defaults
+  this.options(opts.options || {});
 
 Options object
 --------------
@@ -58,7 +65,9 @@ Options object
 An object can be used to customize Linz. For example::
 
   linz.init({
-    'mongo': `mongodb://${process.env.MONGO_HOST}/db`
+      options: {
+          'mongo': `mongodb://${process.env.MONGO_HOST}/db`
+      }
   });
 
 For a complete list of customizations you can make, view Linz's defaults_.
@@ -82,8 +91,10 @@ A common pattern for setting up Linz, using the event emitter, is as follows:
 
   // Initialize Linz.
   linz.init({
-    mongo: `mongodb://${process.env.DB_HOST || 'localhost'}/lmt`,
-    'user model': 'mtUser'
+      options: {
+          mongo: `mongodb://${process.env.DB_HOST || 'localhost'}/lmt`,
+          'user model': 'mtUser'
+      }
   });
 
 **app.js**::

--- a/linz.js
+++ b/linz.js
@@ -156,47 +156,15 @@ var middlewareManager = require('./lib/middleware'),
  * signature: app, mongoose, options
  *
  */
-Linz.prototype.init = function () {
+Linz.prototype.init = function (opts = {}) {
 
-    var _app,
-        _mongoose,
-        _passport,
-        _options;
-
-    // loop through the arguments, and determine what is what
-    for (var i = 0; i < arguments.length; i++) {
-
-        var arg = arguments[i];
-
-        if (arg.constructor.name === 'Mongoose') {
-            debugGeneral('Using passed in mongoose object');
-            _mongoose = arg;
-        } else if (arg.constructor.name === 'Authenticator') {
-            debugGeneral('Using passed in passport object');
-            _passport = arg;
-        } else if ((arg.constructor.name === 'EventEmitter' || arg.constructor.name === 'Function') && typeof arg === 'function') {
-            debugGeneral('Using passed in express app');
-            _app = arg;
-        } else  if (arg.constructor.name === 'Object' && typeof arg === 'object') {
-            debugGeneral('Found options configuration object');
-            _options = arg;
-        }
-
-    }
-
-    // use anything that is passed in
-    _app = _app || express();
-    _mongoose = _mongoose || require('mongoose');
-    _passport = _passport || require('passport');
-    _options = _options || {};
-
-    // reference required properties
-    this.app = _app;
-    this.mongoose = _mongoose;
-    this.passport = _passport;
+    // Use anything that has been passed through, or default it as required.
+    this.app = opts.express || express();
+    this.mongoose = opts.mongoose || require('mongoose');
+    this.passport = opts.passport || require('passport');
 
     // overlay runtime options, these will override linz defaults
-    this.options(_options);
+    this.options(opts.options || {});
 
     // configure everything
     this.configure();

--- a/test/api.js
+++ b/test/api.js
@@ -6,10 +6,12 @@ var expect = require('chai').expect,
 
 // init linz
 linz.init({
-    'mongo': 'mongodb://localhost:27777/mongoose-formtools-test',
-    'user model': 'user',
-    'load models': false,
-    'load configs': false
+    options: {
+        'mongo': 'mongodb://localhost:27777/mongoose-formtools-test',
+        'user model': 'user',
+        'load models': false,
+        'load configs': false
+    }
 });
 
 mongoose = linz.mongoose;


### PR DESCRIPTION
This PR improves Linz's `init` method.

It used to accept Mongoose, Express, Passport and an options object as arguments. Now it expects only one optional argument, an object with optional `mongoose`, `express`, `passport` and `options` keys.

For example:
```
linz.init({
    'express': express(),
    'options': {
        'mongo': 'mongodb://localhost:27777/mongoose-formtools-test',
        'user model': 'user'
    }
});
```

This removes all of the guess work Linz made to determine what was what, as you could also supply those arguments in any order.

### Setup

- [x] Get this branch of Linz up and running in your test environment.

### Testing

- [x] Run the code as is, and it should break (assuming you're passing through arguments).
- [x] Update your code to provide an object.
