### PR TITLE
Add admin home route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Record actions now support `modal: true` to have the URL content displayed within a modal.
 - Fixed issue in which action URLs are sometimes updated twice and then no longer function correctly.
 - Rather than supplying Mongoose, Express, Passport and an options object as arguments to Linz's init function (in any order), Linz now expects an object. The object can have `mongoose`, `express`, `passport` and `options` keys as required.
+- Added ability to customise the homepage route.
 
 ## v1.0.0-8.0.0 (27 March 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Record actions now support `modal: true` to have the URL content displayed within a modal.
 - Fixed issue in which action URLs are sometimes updated twice and then no longer function correctly.
 - Rather than supplying Mongoose, Express, Passport and an options object as arguments to Linz's init function (in any order), Linz now expects an object. The object can have `mongoose`, `express`, `passport` and `options` keys as required.
-- Added ability to customise the homepage route.
+- Added ability to customise the homepage route by setting `admin home` in the `options` object or using `linz.set('admin home', '/new/path')`.
 
 ## v1.0.0-8.0.0 (27 March 2017)
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,9 +2,10 @@
 // define all of the defaults for Linz, these can be overriden
 module.exports = {
 
-	// admin UI
-	'admin path': '/admin',
-	'admin title': 'Linz',
+    // admin UI
+    'admin home': '/models/list',
+    'admin path': '/admin',
+    'admin title': 'Linz',
 
     // password reset related defaults
     'admin forgot password path': '/forgot-your-password',
@@ -12,45 +13,45 @@ module.exports = {
     'admin password pattern': '(?=(?:^.{8,}$))(?=(?:.*?[a-z]{1,}?))(?=(?:.*?[A-Z]{1,}?))(?=(?:.*?[0-9]{1,}?))(?=(?:.*?(?:\\W{1,}?|\\D{1,}?)))',
     'admin password pattern help text': 'Min. 8 characters. Must contain at least 1 uppercase letter, 1 lowercase leter, a symbol (e.g. ! ~ *) and a number.',
 
-	// models
-	'load models': true,
+    // models
+    'load models': true,
 
     // configs
     'load configs': true,
     'configs collection name': 'linzconfigs',
 
-	// user model and authentication
-	'username key': 'username',
-	'password key': 'password',
+    // user model and authentication
+    'username key': 'username',
+    'password key': 'password',
 
-	// error logging and output
-	'error log': console.log,
+    // error logging and output
+    'error log': console.log,
 
-	// admin ui settings
+    // admin ui settings
     'page size': 20,
     'page sizes': [20, 50, 100, 200],
-	'cookie secret': 'oST1Thr2s/iOAUgeK4yuuA==',
-	'date format': 'ddd, ll',
-	'datetime format': 'llll',
-	'set local time': false,
+    'cookie secret': 'oST1Thr2s/iOAUgeK4yuuA==',
+    'date format': 'ddd, ll',
+    'datetime format': 'llll',
+    'set local time': false,
 
-	// permissions
-	'permissions': function (user, context, permission, callback) {
-		return callback(true);
-	},
+    // permissions
+    'permissions': function (user, context, permission, callback) {
+        return callback(true);
+    },
 
-	// sets an array of middleware functions to handle login
-	'login middleware': {
-		get: [require('../middleware-public/login').get],
-		post: [require('../middleware-public/authenticate')('linz-local', { failureFlash: true })]
-	},
+    // sets an array of middleware functions to handle login
+    'login middleware': {
+        get: [require('../middleware-public/login').get],
+        post: [require('../middleware-public/authenticate')('linz-local', { failureFlash: true })]
+    },
 
-	// sets an array of middleware functions to handle logout
-	'logout middleware': {
-		get: [require('../middleware-public/logout')]
-	},
+    // sets an array of middleware functions to handle logout
+    'logout middleware': {
+        get: [require('../middleware-public/logout')]
+    },
 
-	// cache
-	'disable navigation cache': false
+    // cache
+    'disable navigation cache': false
 
 };

--- a/routes/adminHome.js
+++ b/routes/adminHome.js
@@ -1,10 +1,17 @@
-var linz = require('../');
+'use strict';
 
-/* GET /admin */
-var route = function (req, res) {
+const linz = require('../');
+const path = require('path');
 
-	res.redirect(307, linz.get('admin path') + '/models/list');
-
+/**
+ * GET /admin
+ * Admin route redirect.
+ * @param  {Object} req Express Request object.
+ * @param  {Object} res Express Response object.
+ * @return {Void}       Redirects to the admin home.
+ */
+const route = (req, res) => {
+	return res.redirect(307, path.join(linz.get('admin path'), linz.get('admin home')));
 };
 
 module.exports = route;


### PR DESCRIPTION
This PR allows the customisation of the Linz home page.

### Testing

- [x] Nothing should change by default, after passing in a custom `'admin home'` to Linz your app should break (unless that route exists).
