### PR TITLE
Render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed issue in which action URLs are sometimes updated twice and then no longer function correctly.
 - Rather than supplying Mongoose, Express, Passport and an options object as arguments to Linz's init function (in any order), Linz now expects an object. The object can have `mongoose`, `express`, `passport` and `options` keys as required.
 - Added ability to customise the homepage route by setting `admin home` in the `options` object or using `linz.set('admin home', '/new/path')`.
+- Added the ability to render a view in the context of Linz.
 
 ## v1.0.0-8.0.0 (27 March 2017)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,28 +2,32 @@
 
 .. _api-reference:
 
-***********
+*************
 Developer API
-***********
+*************
 
 Linz contains many useful APIs to simplify development.
 
 Views
-===================
+=====
 
-``linz.api.views.render(options, callback)``
+**``linz.api.views.render(options, callback)``**::
 
 Render a template in the context of Linz.
 
-The ``option`` object accepts the following keys:
+The ``options`` object accepts the following keys:
 
 - ``header`` Provide your own header. (wrapper template only)
 - ``body`` Provide the body content.
 - ``page`` Provide the page content. (wrapper template only)
 - ``script`` Provide additional scripts.
-- ``linzNavigation`` Optionally override the navigation.
+- ``linzNavigation`` Optionally override the navigation. (wrapper template only)
 - ``template`` ('wrapper' or 'wrapper-preauth').
 
 The ``callback`` is a standard Node.js callback function ``(err, result)``
 
 You may also provide a ``res`` object that Linz will call to render a template.
+
+**``linz.api.views.viewPath(view)``**::
+
+Get the path to a Linz view.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,29 @@
+.. highlight:: javascript
+
+.. _api-reference:
+
+***********
+Developer API
+***********
+
+Linz contains many useful APIs to simplify development.
+
+Views
+===================
+
+``linz.api.views.render(options, callback)``
+
+Render a template in the context of Linz.
+
+The ``option`` object accepts the following keys:
+
+- ``header`` Provide your own header. (wrapper template only)
+- ``body`` Provide the body content.
+- ``page`` Provide the page content. (wrapper template only)
+- ``script`` Provide additional scripts.
+- ``linzNavigation`` Optionally override the navigation.
+- ``template`` ('wrapper' or 'wrapper-preauth').
+
+The ``callback`` is a standard Node.js callback function ``(err, result)``
+
+You may also provide a ``res`` object that Linz will call to render a template.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Linz is quite new and under rapid development. It is used quite successfully in 
    getting_started
    models
    permissions
+   api
 
 .. _model-docs:
 

--- a/lib/api/views.js
+++ b/lib/api/views.js
@@ -1,5 +1,7 @@
-var linz = require('../../'),
-    path = require('path');
+'use strict';
+
+const linz = require('../../');
+const path = require('path');
 
 /**
  * Return the path to Linz's view directory, appending the specific view if passed in.
@@ -7,10 +9,63 @@ var linz = require('../../'),
  * @return {String}      A path to a particular view file.
  * @api public
  */
-function viewPath (view) {
-    return path.resolve(__dirname, '..', '..', 'views', (view || ''));
-}
+const viewPath = view => path.resolve(__dirname, '..', '..', 'views', (view || ''));
 
-module.exports = {
-    viewPath: viewPath
+/**
+ * Render a template in the context of Linz.
+ * @param  {[type]}   data                  Data and options to pass to the template.
+ * @param  {Function} callback              Optional callback function.
+ * @return {String}                         Renders and returns the template HTML.
+ */
+const render = (data, callback) => {
+
+    const view = viewPath('wrapper.jade');
+
+    // If no callback is provided, use a Promise.
+    if (!callback) {
+
+        return new Promise((resolve, reject) => {
+
+            if (!view) {
+                return reject(new Error('Could not find template.'));
+            }
+
+            linz.app.render(view, data, (err, result) => {
+
+                if (err) {
+                    return reject(err);
+                }
+
+                return resolve(result);
+
+            });
+
+        });
+
+    }
+
+    // If a callback function is provided, render the view and return the results.
+    if (typeof callback === 'function') {
+
+        if (!view) {
+            return callback(new Error('Could not find template.'));
+        }
+
+        linz.app.render(view, data, (err, result) => {
+
+            if (err) {
+                return callback(err);
+            }
+
+            return callback(null, result);
+
+        });
+
+    }
+
+    // If we get to this point, assume callback is a res object.
+    return callback.render(view, data);
+
 };
+
+module.exports = { render, viewPath };

--- a/lib/api/views.js
+++ b/lib/api/views.js
@@ -5,44 +5,27 @@ const path = require('path');
 
 /**
  * Return the path to Linz's view directory, appending the specific view if passed in.
- * @param {String} view  The view to append to the view directory path (a Linz specific view).
- * @return {String}      A path to a particular view file.
+ * @param {String} view The view to append to the view directory path (a Linz specific view).
+ * @return {String}     A path to a particular view file.
  * @api public
  */
 const viewPath = view => path.resolve(__dirname, '..', '..', 'views', (view || ''));
 
 /**
  * Render a template in the context of Linz.
- * @param  {[type]}   data                  Data and options to pass to the template.
- * @param  {Function} callback              Optional callback function.
- * @return {String}                         Renders and returns the template HTML.
+ * @param  {Object}   data     Data and options to pass to the template.
+ * @param  {Function} callback Optional callback function.
+ * @return {String}            Renders and returns the template HTML.
  */
 const render = (data, callback) => {
 
-    const view = viewPath('wrapper.jade');
+    const appLocals = {
+        linzNavigation: linz.get('navigation'),
+        template: 'wrapper'
+    };
 
-    // If no callback is provided, use a Promise.
-    if (!callback) {
-
-        return new Promise((resolve, reject) => {
-
-            if (!view) {
-                return reject(new Error('Could not find template.'));
-            }
-
-            linz.app.render(view, data, (err, result) => {
-
-                if (err) {
-                    return reject(err);
-                }
-
-                return resolve(result);
-
-            });
-
-        });
-
-    }
+    const locals = Object.assign(appLocals, data);
+    const view = viewPath(locals.template + '.jade');
 
     // If a callback function is provided, render the view and return the results.
     if (typeof callback === 'function') {
@@ -51,7 +34,7 @@ const render = (data, callback) => {
             return callback(new Error('Could not find template.'));
         }
 
-        linz.app.render(view, data, (err, result) => {
+        return linz.app.render(view, locals, (err, result) => {
 
             if (err) {
                 return callback(err);
@@ -64,7 +47,7 @@ const render = (data, callback) => {
     }
 
     // If we get to this point, assume callback is a res object.
-    return callback.render(view, data);
+    return callback.render(view, locals);
 
 };
 

--- a/lib/api/views.js
+++ b/lib/api/views.js
@@ -2,6 +2,7 @@
 
 const linz = require('../../');
 const path = require('path');
+const utils = require('../utils');
 
 /**
  * Return the path to Linz's view directory, appending the specific view if passed in.
@@ -24,26 +25,16 @@ const render = (data, callback) => {
         template: 'wrapper'
     };
 
-    const locals = Object.assign(appLocals, data);
+    const locals = utils.merge(appLocals, data || {});
     const view = viewPath(locals.template + '.jade');
+
+    if (!view) {
+        return callback(new Error('Could not find template.'));
+    }
 
     // If a callback function is provided, render the view and return the results.
     if (typeof callback === 'function') {
-
-        if (!view) {
-            return callback(new Error('Could not find template.'));
-        }
-
-        return linz.app.render(view, locals, (err, result) => {
-
-            if (err) {
-                return callback(err);
-            }
-
-            return callback(null, result);
-
-        });
-
+        return linz.app.render(view, locals, callback);
     }
 
     // If we get to this point, assume callback is a res object.

--- a/routes/adminHome.js
+++ b/routes/adminHome.js
@@ -11,7 +11,7 @@ const path = require('path');
  * @return {Void}       Redirects to the admin home.
  */
 const route = (req, res) => {
-	return res.redirect(307, path.join(linz.get('admin path'), linz.get('admin home')));
+	return res.redirect(307, path.posix.resolve(linz.get('admin path'), linz.get('admin home')));
 };
 
 module.exports = route;

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -39,7 +39,7 @@ html(lang="en")&attributes(attributes)
 			ul
 				each node,index in linzNavigation
 					if node.children && node.children.length
-						if node.href === request.path
+						if request && request.path && node.href === request.path
 							li(class='active')
 								mixin submenu(node)
 						else

--- a/views/mixins/navigation.jade
+++ b/views/mixins/navigation.jade
@@ -11,7 +11,7 @@ mixin submenu(node)
 	a(href=node.href)= node.name
 	ul
 		each childNode,childIndex in node.children
-			if (childNode.href === request.path)
+			if (request && request.path && childNode.href === request.path)
 				li(class='active')
 					a(href=childNode.href)= childNode.name
 			else

--- a/views/wrapper-preauth.jade
+++ b/views/wrapper-preauth.jade
@@ -1,0 +1,7 @@
+extends layout-preauth
+
+block content
+	!= body
+
+block script
+	!= script

--- a/views/wrapper.jade
+++ b/views/wrapper.jade
@@ -7,7 +7,15 @@ block content
 	!= body
 
 block page
-	!= page
+	if !page
+		header
+			.container
+				.row
+					.col-xs-12
+						block header
+		block content
+	else
+		!= page
 
 block script
 	!= script

--- a/views/wrapper.jade
+++ b/views/wrapper.jade
@@ -8,3 +8,6 @@ block content
 
 block page
 	!= page
+
+block script
+	!= script


### PR DESCRIPTION
This PR adds the ability to render a view in the context of Linz.

### Testing

- [ ] Pass some data to the render function and see if it works.
```javascript
const options = { page: homepage };

linz.api.views.render(options, (err, html) => {

    if (err) {
        return res.send(err);
    }

    return res.send(html);

});
```
- [ ] By default, nothing should change.
- [ ] Replace the callback function with `res`, it should still work.
- [ ] Add a new key to the options `template: 'wrapper-preauth'`. The view should now display without the navigation components.
