### PR TITLE
Use path.join instead of path.resolve

### DIFF
--- a/routes/adminHome.js
+++ b/routes/adminHome.js
@@ -11,7 +11,7 @@ const path = require('path');
  * @return {Void}       Redirects to the admin home.
  */
 const route = (req, res) => {
-	return res.redirect(307, path.posix.resolve(linz.get('admin path'), linz.get('admin home')));
+    return res.redirect(307, path.join(linz.get('admin path'), linz.get('admin home')));
 };
 
 module.exports = route;


### PR DESCRIPTION
`Path.resolve` strips out the `admin path`, causing 404s. This PR attempts to fix that.