### PR TITLE
Page titles

### DIFF
--- a/routes/modelCreate.js
+++ b/routes/modelCreate.js
@@ -33,15 +33,18 @@ var route = function (req, res, next) {
         ])
             .then(([scripts, styles]) => {
 
+                const singular = inflection.humanize(req.linz.model.linz.formtools.model.label, true);
+
                 return res.render(linz.api.views.viewPath('modelCreate.jade'), {
                     actionUrl: linz.api.url.getAdminLink(req.linz.model, 'create'),
                     cancelUrl: linz.api.url.getAdminLink(req.linz.model),
                     form: editForm.render(),
                     label: {
-                        singular: inflection.humanize(req.linz.model.linz.formtools.model.label, true),
+                        singular,
                         plural: req.linz.model.linz.formtools.model.plural,
                     },
                     model: req.linz.model,
+                    pageTitle: `Create a new ${singular}`,
                     scripts,
                     styles,
                 });

--- a/routes/modelIndex.js
+++ b/routes/modelIndex.js
@@ -57,6 +57,7 @@ var route = function (req, res, next) {
                 modelQuery: JSON.stringify(req.linz.model.formData),
                 page: page,
                 pages: pages,
+                pageTitle: req.linz.model.linz.formtools.model.plural,
                 pageSize: pageSize,
                 pageSizes: req.linz.model.list.paging.sizes || linz.get('page sizes'),
                 pagination: (req.linz.model.list.paging.active === true && total > pageSize),

--- a/routes/modelList.js
+++ b/routes/modelList.js
@@ -69,6 +69,7 @@ var route = function (req, res, next) {
                 return res.render(linz.api.views.viewPath('modelList.jade'), {
                     customAttributes: res.locals.customAttributes,
                     models: modelsList,
+                    pageTitle: 'Models',
                     scripts,
                     styles,
                 });

--- a/routes/recordEdit.js
+++ b/routes/recordEdit.js
@@ -91,6 +91,7 @@ var route = function (req, res, next) {
                     record: req.linz.record,
                     actionUrl: linz.api.url.getAdminLink(req.linz.model, 'save', req.linz.record._id),
                     customAttributes: res.locals.customAttributes,
+                    pageTitle: `Editing '${req.linz.record.title}'`,
                     scripts,
                     styles,
                 });

--- a/routes/recordOverview.js
+++ b/routes/recordOverview.js
@@ -23,6 +23,7 @@ var route = function (req, res, next) {
                 formtools: req.linz.model.linz.formtools,
                 model: req.linz.model,
                 overview: req.linz.overview,
+                pageTitle: req.linz.record.title,
                 permissions: req.linz.model.linz.formtools.permissions,
                 record: clone(req.linz.record.toObject({ virtuals: true})),
                 scripts,


### PR DESCRIPTION
This PR improves Linz by setting pages titles for:

- Home
- Model indexes
- Overviews
- Record edit
- Record create
