### PR TITLE
List count fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unrelease
+
+### IMPROVEMENTS
+
+- Fixed a problem with model lists, showing the wrong number of records. This could occur when a `listQuery` static was employed and have an impact on the number of results being returned.
+
 ## v1.0.0-13.0.0 (3 November 2017)
 
 ### BREAKING CHANGES

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -233,14 +233,10 @@ module.exports = function formtoolsPlugin (schema, options) {
 
     };
 
-    schema.statics.getCount = function (req, filters, cb) {
+    // Take a Mongoose query object, and run a count against it.
+    schema.statics.getCount = function (req, query, cb) {
 
-        // check if owner property exists? if yes filter records by owner
-        if (schema.paths.owner && !filters.owner) {
-            filters.owner = req.user._id;
-        }
-
-        return cb(null, this.count(filters));
+        return cb(null, this.count(query));
 
     }
 

--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -283,10 +283,39 @@ module.exports = function  (req, res, next) {
 
             },
 
+            // minimise the fields we're selecting
+            function (cb) {
+
+                let fields = Object.keys(req.linz.model.list.fields);
+
+                // Work in the title field
+                linz.api.model.titleField(req.params.model, 'title', (err, titleField) => {
+
+                    if (err) {
+                        return cb(err);
+                    }
+
+                    fields.push(titleField);
+
+                    const select = fields.join(' ');
+
+                    query.select(select);
+
+                    // If they've provided the `listQuery` static, use it to allow customisation of the fields we'll retrieve.
+                    if (!req.linz.model.listQuery) {
+                        return cb();
+                    }
+
+                    req.linz.model.listQuery(req, query, cb);
+
+                });
+
+            },
+
             // get page total
             function (cb) {
 
-                req.linz.model.getCount(req, filters, function (err, countQuery) {
+                req.linz.model.getCount(req, query, function (err, countQuery) {
 
                     if (err) {
                         return cb(err);
@@ -312,35 +341,6 @@ module.exports = function  (req, res, next) {
 
                     });
 
-
-                });
-
-            },
-
-            // minimise the fields we're selecting
-            function (cb) {
-
-                let fields = Object.keys(req.linz.model.list.fields);
-
-                // Work in the title field
-                linz.api.model.titleField(req.params.model, 'title', (err, titleField) => {
-
-                    if (err) {
-                        return cb(err);
-                    }
-
-                    fields.push(titleField);
-
-                    const select = fields.join(' ');
-
-                    query.select(select);
-
-                    // If they've provided the `listQuery` static, use it to allow customisation of the fields we'll retrieve.
-                    if (!req.linz.model.listQuery) {
-                        return cb();
-                    }
-
-                    req.linz.model.listQuery(req, query, cb);
 
                 });
 


### PR DESCRIPTION
This PR fixes an issue in which the record count reported on a model list, could be incorrect if the model has been further filtered by a `listQuery` static.

This PR resolves that.

### Setup

- [x] Pull down this branch.
- [x] Wire it up into your project.

### Testing

- [x] Test that record count is accurate, on a model without `listQuery`.
- [x] Add a `listQuery` to your model that will always ensure some records aren't shown. The record count should remain accurate.