### PR TITLE
Replace user with req

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### BREAKING CHANGES
 
 - When rendering the overview, Linz will no longer infer the cell renderer type from the Form DSL type data. If Linz isn't rendering the overview cell with the correct cell renderer, you should supply the renderer (i.e. `{ label: 'x', renderer: linz.formtools.cellRenderers.text }`).
+- When supplying a function for the Model overview DSL, you no longer get passed `user`, but instead `req` (which obvious has user at `req.user`).
 
 ### IMPROVEMENTS
 
 - Fixes `#169`, an issue in which the actions column wouldn't render when permissions weren't explicitly set.
 - Improved the Express param for model. It no longer process list, overview or form DSL. These are now only processed when required. Improving the efficiency of any route that used `:model`.
+- When supplying functions for Model overview DSL, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
 
 ## v1.0.0-13.0.2 (9 November 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@
 ### BREAKING CHANGES
 
 - When rendering the overview, Linz will no longer infer the cell renderer type from the Form DSL type data. If Linz isn't rendering the overview cell with the correct cell renderer, you should supply the renderer (i.e. `{ label: 'x', renderer: linz.formtools.cellRenderers.text }`).
-- When supplying a function for the Model list, form and overview DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
+- When supplying a function for the model list, form and overview DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
+- When supplying a function for the config form and overview DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
 
 ### IMPROVEMENTS
 
 - Fixes `#169`, an issue in which the actions column wouldn't render when permissions weren't explicitly set.
 - Improved the Express param for model. It no longer process list, overview or form DSL. These are now only processed when required. Improving the efficiency of any route that used `:model`.
-- When supplying functions for Model list, form and overview DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.s
+- When supplying functions for model list, form and overview DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
+- When supplying functions for config form and overview DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
 
 ## v1.0.0-13.0.2 (9 November 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### BREAKING CHANGES
 
 - When rendering the overview, Linz will no longer infer the cell renderer type from the Form DSL type data. If Linz isn't rendering the overview cell with the correct cell renderer, you should supply the renderer (i.e. `{ label: 'x', renderer: linz.formtools.cellRenderers.text }`).
-- When supplying a function for the Model overview and list DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
+- When supplying a function for the Model list, form and overview DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
 
 ### IMPROVEMENTS
 
 - Fixes `#169`, an issue in which the actions column wouldn't render when permissions weren't explicitly set.
 - Improved the Express param for model. It no longer process list, overview or form DSL. These are now only processed when required. Improving the efficiency of any route that used `:model`.
-- When supplying functions for Model overview and list DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
+- When supplying functions for Model list, form and overview DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.s
 
 ## v1.0.0-13.0.2 (9 November 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### BREAKING CHANGES
 
 - When rendering the overview, Linz will no longer infer the cell renderer type from the Form DSL type data. If Linz isn't rendering the overview cell with the correct cell renderer, you should supply the renderer (i.e. `{ label: 'x', renderer: linz.formtools.cellRenderers.text }`).
-- When supplying a function for the Model overview DSL, you no longer get passed `user`, but instead `req` (which obvious has user at `req.user`).
+- When supplying a function for the Model overview and list DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
 
 ### IMPROVEMENTS
 
 - Fixes `#169`, an issue in which the actions column wouldn't render when permissions weren't explicitly set.
 - Improved the Express param for model. It no longer process list, overview or form DSL. These are now only processed when required. Improving the efficiency of any route that used `:model`.
-- When supplying functions for Model overview DSL, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
+- When supplying functions for Model overview and list DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
 
 ## v1.0.0-13.0.2 (9 November 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+### IMPROVEMENTS
+
+- Fixes `#169`, an issue in which the actions column wouldn't render when permissions weren't explicitly set.
+
 ## v1.0.0-13.0.2 (9 November 2017)
 
 ### IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,13 @@
 ### BREAKING CHANGES
 
 - When rendering the overview, Linz will no longer infer the cell renderer type from the Form DSL type data. If Linz isn't rendering the overview cell with the correct cell renderer, you should supply the renderer (i.e. `{ label: 'x', renderer: linz.formtools.cellRenderers.text }`).
-- When supplying a function for the model list, form and overview DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
-- When supplying a function for the config form and overview DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
+- When supplying a function for the config form, model list, form and overview DSLs, you no longer get passed `user`, but instead `req` (which obviously has user at `req.user`).
 
 ### IMPROVEMENTS
 
 - Fixes `#169`, an issue in which the actions column wouldn't render when permissions weren't explicitly set.
 - Improved the Express param for model. It no longer process list, overview or form DSL. These are now only processed when required. Improving the efficiency of any route that used `:model`.
-- When supplying functions for model list, form and overview DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
-- When supplying functions for config form and overview DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
+- When supplying functions for config form, model list, form and overview DSLs, you now get `req` rather than just `user`. This provides much more flexibility in what you return, as now it can be based on the record being rendered, not just the user making the request.
 
 ## v1.0.0-13.0.2 (9 November 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v1.0.0-14.0.0 (14 November 2017)
 
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### BREAKING CHANGES
+
+- When rendering the overview, Linz will no longer infer the cell renderer type from the Form DSL type data. If Linz isn't rendering the overview cell with the correct cell renderer, you should supply the renderer (i.e. `{ label: 'x', renderer: linz.formtools.cellRenderers.text }`).
+
 ### IMPROVEMENTS
 
 - Fixes `#169`, an issue in which the actions column wouldn't render when permissions weren't explicitly set.
+- Improved the Express param for model. It no longer process list, overview or form DSL. These are now only processed when required. Improving the efficiency of any route that used `:model`.
 
 ## v1.0.0-13.0.2 (9 November 2017)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Linz is quite new and under rapid development. It is used quite successfully in 
    :caption: Features
 
    notifications
+   request_namespace
 
 .. _advanced-docs:
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -135,7 +135,7 @@ You supply the DSL to Linz in the form of an object, to the ``linz.formtools.plu
 Models model DSL
 ----------------
 
-``model`` should be an object with three keys:
+The ``model`` keys value should be an object with three keys:
 
 - ``title`` is required, unless you have a ``title`` field in your schema. If not, you should reference another field in your schema. This field will be used to derive the *title* for the record, and label for the field.
 - ``label`` should be a singular noun describing the model.
@@ -156,9 +156,9 @@ For example::
 Models label DSL
 ----------------
 
-``labels`` is used to provide a label and description for the model.
+The label DSL is used to provide a label and description for the model.
 
-``labels`` should be an object, keyed by field names and strings of the human friendly versions of your field names.
+The ``labels`` keys value should be an object, keyed by field names and strings of the human friendly versions of your field names.
 
 For example::
 
@@ -174,9 +174,9 @@ You can customize the labels for the default ``dateModified`` and ``dateCreated`
 Models list DSL
 ---------------
 
-``list`` is used to customize the model index that is generated for each model.
+The list DSL is used to customize the model index that is generated for each model.
 
-``list`` should be an Object, containing the following top-level keys:
+The ``list`` keys value should be an Object, containing the following top-level keys:
 
 - ``actions``
 - ``fields``
@@ -191,14 +191,31 @@ Models list DSL
 
 These allow you to describe how the model index should function. The list DSL is discussed in more detail in :ref:`models-list-reference`.
 
+Models list DSL function
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``list`` keys value can also be a function. It should be a function with the following signature::
+
+  function listDSL (req, callback) {
+
+For example::
+
+  {
+    list: (req, callback) => callback(null, {
+      fields: {...}
+    })
+  }
+
+The function receives a HTTP request object, which provides lots of flexibility to alter the DSL object returned based on the user making the request, and the model record itself.
+
 .. _models-form-dsl-summary-reference:
 
 Models form DSL
 ---------------
 
-``form`` is used to customize the model record create and edit pages.
+The form DSL is used to customize the model record create and edit pages.
 
-``form`` should be an Object, keyed by field names of the model, in the order you'd like each field's edit control rendered. For example::
+The ``form`` keys value should be an Object, keyed by field names of the model, in the order you'd like each field's edit control rendered. For example::
 
   form: {
     name: {
@@ -232,6 +249,23 @@ Each field object can contain the following keys:
 - ``relationship``
 
 These allow you to describe how the create and edit forms should function. The form DSL is discussed in more detail in :ref:`models-form-reference`.
+
+Models form DSL function
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``form`` keys value can also be a function. It should be a function with the following signature::
+
+  function formDSL (req, callback) {
+
+For example::
+
+  {
+    form: (req, callback) => callback(null, {
+      name: {...}
+    })
+  }
+
+The function receives a HTTP request object, which provides lots of flexibility to alter the DSL object returned based on the user making the request, and the model record itself.
 
 Model permissions
 -----------------

--- a/docs/request_namespace.rst
+++ b/docs/request_namespace.rst
@@ -1,0 +1,49 @@
+.. highlight:: javascript
+
+*****************
+Request namespace
+*****************
+
+Linz adds to the Express ``req`` object, an object which you can use to access Linz information about the incoming request.
+
+The Linz namespace exists at::
+
+  req.linz
+
+And is a copy of the object you receive when requiring Linz, for example ``require('linz')``.
+
+It has the keys:
+
+- ``notifications`` which is an array of notifications Linz will display.
+- ``cache`` which is an internal cache that Linz uses.
+
+Depending on which view is currently being requested, you'll also get extra information.
+
+The Linz namespace can be used whenever Linz passes you ``req`` and becomes a very handy API to get more infromation about the request currently being served.
+
+Model form
+----------
+
+The model form, both create and edit views, also recieve:
+
+- ``model`` which is a reference to the current model, the basic Mongoose version of the model.
+- ``model.linz`` which is a reference to the current model, which extra Linz-specific information included.
+- ``model.linz.form`` which is a reference to the model form DSL.
+
+Model list
+----------
+
+The model list view also recieves:
+
+- ``model`` which is a reference to the current model, the basic Mongoose version of the model.
+- ``model.linz`` which is a reference to the current model, which extra Linz-specific information included.
+- ``model.linz.list`` which is a reference to the model List DSL.
+
+Model overview
+--------------
+
+The model overview view also recieves:
+
+- ``model`` which is a reference to the current model, the basic Mongoose version of the model.
+- ``model.linz`` which is a reference to the current model, which extra Linz-specific information included.
+- ``model.linz.overview`` which is a reference to the model overview DSL.

--- a/lib/api/configs.js
+++ b/lib/api/configs.js
@@ -63,7 +63,7 @@ function form (req, configName, callback) {
 
 /**
  * Retrieve the overview DSL for a config
- * @param  {Object}   req      A HTTP request object which should be used to customise the DSL
+ * @param  {Object}   req      A HTTP request object which can be used to customise the DSL
  * @param  {String}   configName The name of the config
  * @param  {Function} callback  A callback to return the overview DSL to
  * @return {Void}

--- a/lib/api/configs.js
+++ b/lib/api/configs.js
@@ -52,24 +52,24 @@ function permissions (user, configName, callback) {
 
 /**
  * Retrieve the form DSL for a config
- * @param  {Object}   user      The user to which the form DSL should be customised
+ * @param  {Object}   req      A HTTP request object which should be used to customise the DSL
  * @param  {String}   configName The name of the config
  * @param  {Function} callback  A callback to return the form DSL to
  * @return {Void}
  */
-function form (user, configName, callback) {
-    return get(configName).schema.statics.getForm(user, callback);
+function form (req, configName, callback) {
+    return get(configName).schema.statics.getForm(req, callback);
 }
 
 /**
  * Retrieve the overview DSL for a config
- * @param  {Object}   user      The user to which the overview DSL should be customised
+ * @param  {Object}   req      A HTTP request object which should be used to customise the DSL
  * @param  {String}   configName The name of the config
  * @param  {Function} callback  A callback to return the overview DSL to
  * @return {Void}
  */
-function overview (user, configName, callback) {
-    return get(configName).schema.statics.getOverview(user, callback);
+function overview (req, configName, callback) {
+    return get(configName).schema.statics.getOverview(req, callback);
 }
 
 /**

--- a/lib/api/formtools/list.js
+++ b/lib/api/formtools/list.js
@@ -17,7 +17,7 @@ function renderToolbarItems (req, res, modelName, cb) {
         throw new Error('modelName is required and must be of type String and cannot be empty.');
     }
 
-    linz.api.model.list(req.user, modelName, function (err, list) {
+    linz.api.model.list(req, modelName, function (err, list) {
 
         if (err) {
             return cb(err);
@@ -55,22 +55,23 @@ function renderToolbarItems (req, res, modelName, cb) {
 
 /**
  * Get list filter settings and execute render method to obtain the HTML markup
+ * @param {String}   req       A HTTP request object.
  * @param {String}   modelName Name of model
  * @param {Function} cb        Callback function
  * @return {Object} or undefined
  * @api public
  */
-function renderFilters (user, modelName, cb) {
+function renderFilters (req, modelName, cb) {
 
-    if (!user) {
-        throw new Error('user is required.');
+    if (!req) {
+        throw new Error('req is required.');
     }
 
     if (typeof modelName !== 'string' || !modelName.length) {
         throw new Error('modelName is required and must be of type String and cannot be empty.');
     }
 
-    linz.api.model.list(user, modelName, function (err, list) {
+    linz.api.model.list(req, modelName, function (err, list) {
 
         if (err) {
             return cb(err);
@@ -114,10 +115,10 @@ function renderFilters (user, modelName, cb) {
  * @return {Object} or undefined
  * @api public
  */
-function renderSearchFilters(user, fieldNames, data, modelName, cb) {
+function renderSearchFilters(req, fieldNames, data, modelName, cb) {
 
-    if (!user) {
-        throw new Error('user is required.');
+    if (!req) {
+        throw new Error('req is required.');
     }
 
     if (!Array.isArray(fieldNames) || !fieldNames.length) {
@@ -135,7 +136,7 @@ function renderSearchFilters(user, fieldNames, data, modelName, cb) {
     // Sort fieldNames (to make MongoDB queries more predictable, and therefore easier to create indexes for), remove duplicates, and remove anything that doesn't have associated data.
     fieldNames = dedupe(fieldNames.sort().filter(fieldName => Object.keys(data).indexOf(fieldName) >= 0));
 
-    linz.api.model.list(user, modelName, function (err, list) {
+    linz.api.model.list(req, modelName, function (err, list) {
 
         if (err) {
             return cb(err);
@@ -193,10 +194,10 @@ function renderSearchFilters(user, fieldNames, data, modelName, cb) {
  * @return {Object} or undefined
  * @api public
  */
-function getActiveFilters (user, selectedFilters, data, modelName, cb) {
+function getActiveFilters (req, selectedFilters, data, modelName, cb) {
 
-    if (!user) {
-        throw new Error('user is required.');
+    if (!req) {
+        throw new Error('req is required.');
     }
 
     if (!selectedFilters || !Array.isArray(selectedFilters) || !selectedFilters.length) {
@@ -211,7 +212,7 @@ function getActiveFilters (user, selectedFilters, data, modelName, cb) {
         throw new Error('data is required and must be of type Object.');
     }
 
-    linz.api.model.list(user, modelName, function (err, list) {
+    linz.api.model.list(req, modelName, function (err, list) {
 
         if (err) {
             return cb(err);

--- a/lib/api/model.js
+++ b/lib/api/model.js
@@ -39,18 +39,18 @@ function hasPermission (user, modelName, permission, callback) {
 
 /**
  * Retrieve the form DSL for a model
- * @param  {Object}   user      The user to which the form should be customised
+ * @param  {Object}   req       A HTTP request object which can be used to customised the form
  * @param  {String}   modelName The name of the model
  * @param  {Function} callback  A callback to return the form DSL to
  * @return {Void}
  */
-function form (user, modelName, callback) {
-    return get(modelName, true).getForm(user, callback);
+function form (req, modelName, callback) {
+    return get(modelName, true).getForm(req, callback);
 }
 
 /**
  * Retrieve the list DSL for a model
- * @param  {Object}   user      The user to which the list should be customised
+ * @param  {Object}   req       A HTTP request object which can be used to customised the list
  * @param  {String}   modelName The name of the model
  * @param  {Function} callback  A callback to return the list DSL to
  * @return {Void}
@@ -82,7 +82,7 @@ function permissions (user, modelName, callback) {
 
 /**
  * Retrieve the overview DSL for a model
- * @param  {Object}   req       A HTTP request object
+ * @param  {Object}   req       A HTTP request object which can be used to customised the overview
  * @param  {String}   modelName The name of the model
  * @param  {Function} callback  A callback to return the overview DSL to
  * @return {Void}

--- a/lib/api/model.js
+++ b/lib/api/model.js
@@ -83,13 +83,12 @@ function permissions (user, modelName, callback) {
 /**
  * Retrieve the overview DSL for a model
  * @param  {Object}   req       A HTTP request object
- * @param  {Object}   user      The user to which the overview DSL should be customised
  * @param  {String}   modelName The name of the model
  * @param  {Function} callback  A callback to return the overview DSL to
  * @return {Void}
  */
-function overview (req, user, modelName, callback) {
-    return get(modelName, true).getOverview(req, user, callback);
+function overview (req, modelName, callback) {
+    return get(modelName, true).getOverview(req, callback);
 }
 
 /**

--- a/lib/api/model.js
+++ b/lib/api/model.js
@@ -82,13 +82,14 @@ function permissions (user, modelName, callback) {
 
 /**
  * Retrieve the overview DSL for a model
+ * @param  {Object}   req       A HTTP request object
  * @param  {Object}   user      The user to which the overview DSL should be customised
  * @param  {String}   modelName The name of the model
  * @param  {Function} callback  A callback to return the overview DSL to
  * @return {Void}
  */
-function overview (user, modelName, callback) {
-    return get(modelName, true).getOverview(user, callback);
+function overview (req, user, modelName, callback) {
+    return get(modelName, true).getOverview(req, user, callback);
 }
 
 /**

--- a/lib/api/model.js
+++ b/lib/api/model.js
@@ -55,8 +55,8 @@ function form (user, modelName, callback) {
  * @param  {Function} callback  A callback to return the list DSL to
  * @return {Void}
  */
-function list (user, modelName, callback) {
-    return get(modelName, true).getList(user, callback);
+function list (req, modelName, callback) {
+    return get(modelName, true).getList(req, callback);
 }
 
 /**

--- a/lib/formtools/form.js
+++ b/lib/formtools/form.js
@@ -232,7 +232,7 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
                         break;
 
                         case 'datetime':
-                        fieldValue = ((r[fieldName] !== undefined && r[fieldName] !== null) ? r[fieldName].toISOString().slice(0,23) : defaultValue) || defaultValue;
+                        fieldValue = ((r[fieldName] !== undefined && r[fieldName] !== null && (r[fieldName]) instanceof Date) ? r[fieldName].toISOString().slice(0,23) : defaultValue) || defaultValue;
                         break;
 
                         case 'boolean':

--- a/lib/formtools/overview.js
+++ b/lib/formtools/overview.js
@@ -28,7 +28,7 @@ function setTabId (sections) {
 }
 
 /**
- * Rrturn the rendered value of field
+ * Return the rendered value of field.
  * @param  {Object}   record Overview record object
  * @param  {Object or String} Field name or Object containing field name and field label
  * @param  {Obect}   model  Model object
@@ -38,10 +38,7 @@ function setTabId (sections) {
 function renderCell (record, field, model, cb) {
 
     let fieldName = (typeof field === 'object') ? field.fieldName : field,
-        formField = model.linz.formtools.form[fieldName],
-        renderer = cellRenderers[formField.type] ?
-        formField.type :
-        (model.schema.tree[fieldName] && model.schema.tree[fieldName].ref && linz.api.model.getObjectIdFromRefField(record[fieldName]) instanceof linz.mongoose.Types.ObjectId) ?
+        renderer = (model.schema.tree[fieldName] && model.schema.tree[fieldName].ref && linz.api.model.getObjectIdFromRefField(record[fieldName]) instanceof linz.mongoose.Types.ObjectId) ?
             'reference' :
             (record[fieldName] && linz.api.model.getObjectIdFromRefField(record[fieldName]) instanceof linz.mongoose.Types.ObjectId && linz.mongoose.models[record[fieldName].ref]) ? 'referenceValue' :
                 'text';
@@ -76,15 +73,19 @@ function renderFields(req, res, record, model, section, callback) {
     // filter out invalid fields from section
     var fields = section.fields.filter(function (field) {
 
-        if (typeof field !== 'object') {
-            return model.linz.formtools.form[field];
-        }
-
         if (typeof field.value === 'function') {
             return field.label;
         }
 
-        return field.fieldName ;
+        // Dynamically build the object.
+        if (typeof field !== 'object') {
+            return {
+                label: model.linz.formtools.labels[field],
+                value: record[field],
+            };
+        }
+
+        return field.fieldName;
 
     });
 

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -161,7 +161,7 @@ module.exports = function formtoolsPlugin (schema, options) {
     };
 
     // setup a method to retrieve the form object
-    schema.statics.getForm = function (user, cb) {
+    schema.statics.getForm = function (req, cb) {
 
         // if form is defined, that means it was provided as an object DSL, let's return the formatted version
         if (form) {
@@ -169,7 +169,7 @@ module.exports = function formtoolsPlugin (schema, options) {
         }
 
         // if we have a function, let's call it
-        opts.form(user, function (err, customForm) {
+        opts.form(req, function (err, customForm) {
 
             // simply return any error
             if (err) {

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -184,7 +184,7 @@ module.exports = function formtoolsPlugin (schema, options) {
     };
 
     // setup a method to retrieve the field list
-    schema.statics.getOverview = function (req, user, cb) {
+    schema.statics.getOverview = function (req, cb) {
 
         // if overview is defined, that means it was provided as an object DSL, let's return the formatted version
         if (overview) {
@@ -192,7 +192,7 @@ module.exports = function formtoolsPlugin (schema, options) {
         }
 
         // if we have a function, let's call it
-        opts.overview(req, user, function (err, customOverview) {
+        opts.overview(req, function (err, customOverview) {
 
             // simply return any error
             if (err) {

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -184,7 +184,7 @@ module.exports = function formtoolsPlugin (schema, options) {
     };
 
     // setup a method to retrieve the field list
-    schema.statics.getOverview = function (user, cb) {
+    schema.statics.getOverview = function (req, user, cb) {
 
         // if overview is defined, that means it was provided as an object DSL, let's return the formatted version
         if (overview) {
@@ -192,7 +192,7 @@ module.exports = function formtoolsPlugin (schema, options) {
         }
 
         // if we have a function, let's call it
-        opts.overview(user, function (err, customOverview) {
+        opts.overview(req, user, function (err, customOverview) {
 
             // simply return any error
             if (err) {

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -140,7 +140,7 @@ module.exports = function formtoolsPlugin (schema, options) {
     };
 
     // setup a method to retrieve the field list
-    schema.statics.getList = function (user, cb) {
+    schema.statics.getList = function (req, cb) {
 
         // if list is defined, that means it was provided as an object DSL, let's return the formatted version
         if (list) {
@@ -148,7 +148,7 @@ module.exports = function formtoolsPlugin (schema, options) {
         }
 
         // otherwise, the list object will be specific to user and needs to be run multiple times
-        return opts.list(user, function (err, customList) {
+        return opts.list(req, function (err, customList) {
 
             if (err) {
                 return cb(err);

--- a/lib/formtools/plugins/embedded-document.js
+++ b/lib/formtools/plugins/embedded-document.js
@@ -36,7 +36,7 @@ module.exports = function formtoolsEmbeddedDocumentPlugin (schema, options) {
     }
 
     // Setup a method to retrieve the form DSL.
-    schema.statics.getForm = function (user, cb) {
+    schema.statics.getForm = function (req, cb) {
 
         // if form is defined, that means it was provided as an object DSL, let's return the formatted version
         if (form) {
@@ -44,7 +44,7 @@ module.exports = function formtoolsEmbeddedDocumentPlugin (schema, options) {
         }
 
         // if we have a function, let's call it
-        options.form(user, function (err, customForm) {
+        options.form(req, function (err, customForm) {
 
             // simply return any error
             if (err) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -48,16 +48,16 @@ exports.setupModelRoutes = function () {
 
     // model routes
     router.get('/models/list', middleware.permissions('canList', 'models'), routes.modelList);
-    router.get('/model/:model/list', middleware.permissions('canList', 'model'), middleware.modelIndex.get, routes.modelIndex);
-    router.post('/model/:model/list', middleware.permissions('canList', 'model'), middleware.modelIndex.post, routes.modelIndex);
-    router.get('/model/:model/new', middleware.permissions('canCreate', 'model'), middleware.modelCreate(), routes.modelCreate);
+    router.get('/model/:model/list', middleware.namespaceList, middleware.permissions('canList', 'model'), middleware.modelIndex.get, routes.modelIndex);
+    router.post('/model/:model/list', middleware.namespaceList, middleware.permissions('canList', 'model'), middleware.modelIndex.post, routes.modelIndex);
+    router.get('/model/:model/new', middleware.namespaceForm, middleware.permissions('canCreate', 'model'), middleware.modelCreate(), routes.modelCreate);
     router.post('/model/:model/create', middleware.permissions('canCreate', 'model'), middleware.modelSave(), routes.modelSave);
     router.get('/model/:model/export', middleware.permissions('canExport', 'model'), middleware.modelExport.get, routes.modelExport.get);
     router.post('/model/:model/export', middleware.permissions('canExport', 'model'), middleware.modelExport.post);
 
     // record routes
-    router.get('/model/:model/:id/overview', middleware.permissions('canView', 'model'), middleware.recordOverview(), routes.recordOverview);
-    router.get('/model/:model/:id/edit', middleware.permissions('canEdit', 'model'), middleware.recordEdit(), routes.recordEdit);
+    router.get('/model/:model/:id/overview', middleware.namespaceOverview, middleware.permissions('canView', 'model'), middleware.recordOverview(), routes.recordOverview);
+    router.get('/model/:model/:id/edit', middleware.namespaceForm, middleware.permissions('canEdit', 'model'), middleware.recordEdit(), routes.recordEdit);
     router.post('/model/:model/:id/save', middleware.permissions('canEdit', 'model'), middleware.recordSave(), routes.recordSave);
     router.get('/model/:model/:id/delete', middleware.permissions('canDelete', 'model'), middleware.recordDelete(), routes.recordDelete);
     router.get('/model/:model/:id/json', middleware.permissions('canViewRaw', 'model'), routes.recordJSON);

--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -123,7 +123,7 @@ module.exports = function  (req, res, next) {
                     return cb(null);
                 }
 
-                formtoolsAPI.list.renderFilters(req.user, req.params.model, function (err, result) {
+                formtoolsAPI.list.renderFilters(req, req.params.model, function (err, result) {
 
                     if (err) {
                         return cb(err);
@@ -197,7 +197,7 @@ module.exports = function  (req, res, next) {
                     return cb(null);
                 }
 
-                formtoolsAPI.list.getActiveFilters(req.user, session.list.formData.selectedFilters.split(','), session.list.formData, req.params.model, function (err, result) {
+                formtoolsAPI.list.getActiveFilters(req, session.list.formData.selectedFilters.split(','), session.list.formData, req.params.model, function (err, result) {
 
                     if (err) {
                         return cb(err);
@@ -218,7 +218,7 @@ module.exports = function  (req, res, next) {
                     return cb(null);
                 }
 
-                formtoolsAPI.list.renderSearchFilters(req.user, session.list.formData.selectedFilters.split(','), session.list.formData, req.params.model, function (err, result) {
+                formtoolsAPI.list.renderSearchFilters(req, session.list.formData.selectedFilters.split(','), session.list.formData, req.params.model, function (err, result) {
 
                     if (err) {
                         return cb(err);

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -124,7 +124,7 @@ var modelExportHelpers = function modelExportHelpers (req, res) {
 
                 function (callback) {
 
-                    Model.getList(req.user, function (err, list) {
+                    Model.getList(req, function (err, list) {
 
                         if (err) {
                             return cb(err);
@@ -211,7 +211,7 @@ var modelExportHelpers = function modelExportHelpers (req, res) {
 
         getList: function getList (filters, form, cb) {
 
-            req.linz.model.getList(req.user, function (err, list) {
+            req.linz.model.getList(req, function (err, list) {
                 return cb(err, filters, form, list);
             });
 
@@ -251,7 +251,7 @@ module.exports = {
 
     get: function (req, res, next) {
 
-        req.linz.model.getList(req.user, function (err, list) {
+        req.linz.model.getList(req, function (err, list) {
 
             if (err) {
                 return next(err);

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -203,7 +203,7 @@ var modelExportHelpers = function modelExportHelpers (req, res) {
 
         getForm: function getForm(filters, cb) {
 
-            req.linz.model.getForm(req.user, function (err, form) {
+            req.linz.model.getForm(req, function (err, form) {
                 return cb(err, filters, form);
             });
 
@@ -265,7 +265,7 @@ module.exports = {
             req.linz.export.fields = {};
 
             // retrieve the form to provide a list of fields to choose from
-            req.linz.model.getForm(req.user, function (formErr, form){
+            req.linz.model.getForm(req, function (formErr, form){
 
                 if (formErr) {
                     return next(formErr);

--- a/middleware/modelSave.js
+++ b/middleware/modelSave.js
@@ -1,10 +1,9 @@
-var linz = require('../');
 
 module.exports = function () {
 
 	return function (req, res, next) {
 
-        req.linz.model.getForm(req.user, function(err, form) {
+        req.linz.model.getForm(req, function(err, form) {
 
             req.linz.model.form = form;
             next();

--- a/middleware/namespace.js
+++ b/middleware/namespace.js
@@ -8,11 +8,6 @@ module.exports = function linzNamespace (req, res, next) {
     req.linz.cache = req.linz.cache || {};
     req.linz.cache.navigation = req.linz.cache.navigation || {};
     req.linz.cache.navigation.invalidate = req.linz.cache.navigation.invalidate || false;
-    req.linz.cache.permissions = req.linz.cache.permissions || {};
-    req.linz.cache.permissions.configs = req.linz.cache.permissions.configs || {};
-    req.linz.cache.permissions.configs.invalidate = req.linz.cache.permissions.configs.invalidate || false;
-    req.linz.cache.permissions.models = req.linz.cache.permissions.models || {};
-    req.linz.cache.permissions.models.invalidate = req.linz.cache.permissions.models.invalidate || false;
 
     return next();
 

--- a/middleware/namespaceForm.js
+++ b/middleware/namespaceForm.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const linz = require('linz');
+const async = require('async');
+
+// This namespace will by used by Linz.
+module.exports = function linzNamespaceForm (req, res, next) {
+
+    // Setup the shared formtools data for this particular request.
+    async.parallel([
+
+        function(cb) {
+
+            linz.api.model.form(req.user, req.linz.model.modelName, function(err, form) {
+
+                if (err) {
+                    return cb(err);
+                }
+
+                req.linz.model.linz.formtools.form = form;
+
+                return cb(null);
+
+            });
+
+        },
+
+        function(cb) {
+
+            // loop through each of the keys to determine if we have an embedded document
+            // if we do, we need to call getForm with the user
+            var form = req.linz.model.linz.formtools.form;
+
+            async.forEachOf(form, function(field, key, callback) {
+
+                // if field is not of type documentarray or if it is, it's not implementing the embedded document plugin, exit
+                // if (field.type !== 'documentarray') {
+                if (field.type !== 'documentarray' || !field.schema.statics.getForm) {
+                    return callback();
+                }
+
+                // Setup the placeholder for the embedded document. Retrieve the labels.
+                field.linz = {
+                    formtools: {
+                        labels: field.schema.statics.getLabels()
+                    }
+                };
+
+                // Retrieve the form.
+                field.schema.statics.getForm(req.user, function(err, embeddedForm) {
+
+                    if (embeddedForm) {
+                        field.linz.formtools.form = embeddedForm;
+                    }
+
+                    return callback(err);
+
+                });
+
+            }, cb);
+
+        }
+
+    ], next);
+
+}

--- a/middleware/namespaceForm.js
+++ b/middleware/namespaceForm.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const linz = require('linz');
+const linz = require('../');
 const async = require('async');
 
 // This namespace will by used by Linz.

--- a/middleware/namespaceForm.js
+++ b/middleware/namespaceForm.js
@@ -11,7 +11,7 @@ module.exports = function linzNamespaceForm (req, res, next) {
 
         function(cb) {
 
-            linz.api.model.form(req.user, req.linz.model.modelName, function(err, form) {
+            linz.api.model.form(req, req.linz.model.modelName, function(err, form) {
 
                 if (err) {
                     return cb(err);
@@ -47,7 +47,7 @@ module.exports = function linzNamespaceForm (req, res, next) {
                 };
 
                 // Retrieve the form.
-                field.schema.statics.getForm(req.user, function(err, embeddedForm) {
+                field.schema.statics.getForm(req, function(err, embeddedForm) {
 
                     if (embeddedForm) {
                         field.linz.formtools.form = embeddedForm;

--- a/middleware/namespaceList.js
+++ b/middleware/namespaceList.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const linz = require('linz');
+const linz = require('../');
 
 // This namespace will by used by Linz.
 module.exports = function linzNamespaceList (req, res, next) {

--- a/middleware/namespaceList.js
+++ b/middleware/namespaceList.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const linz = require('linz');
+
+// This namespace will by used by Linz.
+module.exports = function linzNamespaceList (req, res, next) {
+
+    linz.api.model.list(req.user, req.linz.model.modelName, function(err, list) {
+
+        if (err) {
+            return next(err);
+        }
+
+        req.linz.model.linz.formtools.list = list;
+
+        return next();
+
+    });
+
+}

--- a/middleware/namespaceList.js
+++ b/middleware/namespaceList.js
@@ -5,7 +5,7 @@ const linz = require('../');
 // This namespace will by used by Linz.
 module.exports = function linzNamespaceList (req, res, next) {
 
-    linz.api.model.list(req.user, req.linz.model.modelName, function(err, list) {
+    linz.api.model.list(req, req.linz.model.modelName, function(err, list) {
 
         if (err) {
             return next(err);

--- a/middleware/namespaceOverview.js
+++ b/middleware/namespaceOverview.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const linz = require('linz');
+const linz = require('../');
 
 // This namespace will by used by Linz.
 module.exports = function linzNamespaceOverview (req, res, next) {

--- a/middleware/namespaceOverview.js
+++ b/middleware/namespaceOverview.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const linz = require('linz');
+
+// This namespace will by used by Linz.
+module.exports = function linzNamespaceOverview (req, res, next) {
+
+    linz.api.model.overview(req, req.user, req.linz.model.modelName, function(err, overview) {
+
+        if (err) {
+            return next(err);
+        }
+
+        req.linz.model.linz.formtools.overview = overview;
+
+        return next();
+
+    });
+
+}

--- a/middleware/namespaceOverview.js
+++ b/middleware/namespaceOverview.js
@@ -5,7 +5,7 @@ const linz = require('../');
 // This namespace will by used by Linz.
 module.exports = function linzNamespaceOverview (req, res, next) {
 
-    linz.api.model.overview(req, req.user, req.linz.model.modelName, function(err, overview) {
+    linz.api.model.overview(req, req.linz.model.modelName, function(err, overview) {
 
         if (err) {
             return next(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-13.0.2",
+  "version": "1.0.0-14.0.0",
   "description": "Node.js web application framework",
   "main": "linz.js",
   "scripts": {

--- a/params/config.js
+++ b/params/config.js
@@ -39,7 +39,7 @@ module.exports = function (router) {
 
 			function (cb) {
 
-				linz.api.configs.form(req.user, configName, function (err, form) {
+				linz.api.configs.form(req, configName, function (err, form) {
 
 					if (err) {
 						return cb(err);
@@ -55,7 +55,7 @@ module.exports = function (router) {
 
 			function (cb) {
 
-				linz.api.configs.overview(req.user, configName, function (err, overview) {
+				linz.api.configs.overview(req, configName, function (err, overview) {
 
 					if (err) {
 						return cb(err);

--- a/params/model.js
+++ b/params/model.js
@@ -1,136 +1,47 @@
-
 var linz = require('../'),
-	async = require('async');
+    async = require('async');
 
-module.exports = function (router) {
+module.exports = function(router) {
 
-	// set the model param on the linz namespace
-	router.param('model', function (req, res, next, modelName) {
+    // Set the model param on the linz namespace.
+    router.param('model', function(req, res, next, modelName) {
 
-		// grab the model
-		req.linz.model = linz.api.model.get(modelName);
+        // grab the model
+        req.linz.model = linz.api.model.get(modelName);
 
-		// setup the formtools data for this particular request
-		async.parallel([
+        // Setup the shared formtools data for this particular request.
+        async.parallel([
 
-			function (cb) {
+            function(cb) {
 
-				req.linz.model.linz.formtools.labels = linz.api.model.labels(modelName);
+                req.linz.model.linz.formtools.labels = linz.api.model.labels(modelName);
 
-				return cb();
+                return cb();
 
-			},
+            },
 
-			function (cb) {
+            function(cb) {
 
-				linz.api.model.list(req.user, modelName, function (err, list) {
+                linz.api.model.permissions(req.user, modelName, function(err, permissions) {
 
-					if (err) {
-						return cb(err);
-					}
+                    if (err) {
+                        return cb(err);
+                    }
 
-					req.linz.model.linz.formtools.list = list;
+                    req.linz.model.linz.formtools.permissions = permissions;
 
-					return cb(null);
+                    return cb(null);
 
-				});
+                });
 
-			},
+            },
 
-			function (cb) {
+        ], function(err) {
 
-				linz.api.model.permissions(req.user, modelName, function (err, permissions) {
+            return next(err);
 
-					if (err) {
-						return cb(err);
-					}
+        });
 
-					req.linz.model.linz.formtools.permissions = permissions;
-
-					return cb(null);
-
-				});
-
-			},
-
-			function (cb) {
-
-				linz.api.model.form(req.user, modelName, function (err, form) {
-
-					if (err) {
-						return cb(err);
-					}
-
-					req.linz.model.linz.formtools.form = form;
-
-					return cb(null);
-
-				});
-
-			},
-
-			function (cb) {
-
-				linz.api.model.overview(req.user, modelName, function (err, overview) {
-
-					if (err) {
-						return cb(err);
-					}
-
-					req.linz.model.linz.formtools.overview = overview;
-
-					return cb(null);
-
-				});
-
-			},
-
-			function (cb) {
-
-				// loop through each of the keys to determine if we have an embedded document
-				// if we do, we need to call getForm with the user
-				var form = req.linz.model.linz.formtools.form;
-
-				async.forEachOf(form, function (field, key, callback) {
-
-					// if field is not of type documentarray or if it is, it's not implementing the embedded document plugin, exit
-					// if (field.type !== 'documentarray') {
-					if (field.type !== 'documentarray' || !field.schema.statics.getForm) {
-						return callback();
-					}
-
-					// Setup the placeholder for the embedded document. Retrieve the labels.
-					field.linz = {
-						formtools: {
-							labels: field.schema.statics.getLabels()
-						}
-					};
-
-					// Retrieve the form.
-					field.schema.statics.getForm(req.user, function (err, embeddedForm) {
-
-						if (embeddedForm) {
-							field.linz.formtools.form = embeddedForm;
-						}
-
-						return callback(err);
-
-					});
-
-				}, function (err) {
-
-					return cb(null);
-
-				});
-
-			}
-
-		], function (err) {
-
-			return next(err);
-
-		});
-
-	});
+    });
 
 };

--- a/routes/modelSave.js
+++ b/routes/modelSave.js
@@ -1,5 +1,4 @@
-var formist = require('formist'),
-	linz = require('../'),
+var linz = require('../'),
     model = require('../lib/formtools/model'),
     async = require('async'),
     utils = require('../lib/utils'),
@@ -12,7 +11,7 @@ var route = function (req, res, next) {
 
         function (done) {
 
-            req.linz.model.getForm(req.user, function (err, form) {
+            req.linz.model.getForm(req, function (err, form) {
 
                 // retrieve form information, for use in next function
                 req.linz.model.form = form;

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -680,14 +680,14 @@ describe('formtools', function () {
                 },
 
                 function (cb) {
-                    PostModel.getOverview({}, undefined, function (err, result) {
+                    PostModel.getOverview({}, function (err, result) {
                         overviewOpts = result;
                         cb(null);
                     });
                 },
 
                 function (cb) {
-                    OverridesPostModel.getOverview({}, undefined, function (err, result) {
+                    OverridesPostModel.getOverview({}, function (err, result) {
                         overridesOverviewOpts = result;
                         cb(null);
                     });

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -652,7 +652,7 @@ describe('formtools', function () {
                 },
 
                 function (cb) {
-                    PostModel.getForm(undefined, function (err, result) {
+                    PostModel.getForm({}, function (err, result) {
                         formOpts = result;
                         cb(null);
                     });
@@ -673,7 +673,7 @@ describe('formtools', function () {
                 },
 
                 function (cb) {
-                    OverridesPostModel.getForm(undefined, function (err, result) {
+                    OverridesPostModel.getForm({}, function (err, result) {
                         overridesFormOpts = result;
                         cb(null);
                     });

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -680,14 +680,14 @@ describe('formtools', function () {
                 },
 
                 function (cb) {
-                    PostModel.getOverview(undefined, function (err, result) {
+                    PostModel.getOverview({}, undefined, function (err, result) {
                         overviewOpts = result;
                         cb(null);
                     });
                 },
 
                 function (cb) {
-                    OverridesPostModel.getOverview(undefined, function (err, result) {
+                    OverridesPostModel.getOverview({}, undefined, function (err, result) {
                         overridesOverviewOpts = result;
                         cb(null);
                     });

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -638,14 +638,14 @@ describe('formtools', function () {
                 },
 
                 function (cb) {
-                    PostModel.getList(undefined, function (err, result) {
+                    PostModel.getList({}, function (err, result) {
                         listOpts = result;
                         cb(null);
                     });
                 },
 
                 function (cb) {
-                    OverridesPostModel.getList(undefined, function (err, result) {
+                    OverridesPostModel.getList({}, function (err, result) {
                         overridesListOpts = result;
                         cb(null);
                     });

--- a/views/modelIndex/grid.jade
+++ b/views/modelIndex/grid.jade
@@ -7,7 +7,7 @@
                         if model.list.groupActions && model.list.groupActions.length
                             th
                                 input(type="checkbox", data-linz-control="checked-all")
-                        if permissions.canEdit || permissions.canDelete || model.list.recordActions.length || model.list.primaryRecordActions.length
+                        if permissions.canEdit !== false || permissions.canDelete !== false || model.list.recordActions.length || model.list.primaryRecordActions.length
                             th.actions Actions
                         for field in model.list.fields
                             th= field.label
@@ -18,7 +18,7 @@
                             if model.list.groupActions && model.list.groupActions.length
                                 td
                                     input(type="checkbox", name="ids[]", value="#{record._id}", data-linz-control="checked-record")
-                            if permissions.canEdit || permissions.canDelete || model.list.recordActions.length || model.list.primaryRecordActions.length
+                            if permissions.canEdit !== false || permissions.canDelete !== false || model.list.recordActions.length || model.list.primaryRecordActions.length
                                 td!= record.actionsTemplate
 
                             each val in Object.keys(model.list.fields)


### PR DESCRIPTION
This PR will add more flexibility in what you can do with the model form, list and overview DSLs. Before this PR, when using a function, you could only base the result on the user making the request. This PR allows you to base the result on the record itself and the user making the request as these functions are now passed `req`, rather than `user`.

This is the first in a new direction where all future APIs will involved passing `req` where possible.

### Setup

- [ ] Pull down this branch, and map it into your project.

### Testing

- [ ] Before updating your project, your list, form and overview views should either break or not work properly if you're providing a function.
- [ ] Update your functions to accept `req` rather than `user`.
- [ ] Check that the model form function receives `req`, and can be rendered properly.
- [ ] Check that the model list function receives `req` and can be rendered properly.
- [ ] Check that the model overview function receives `req`, and can be rendered properly.
- [ ] Check that the config form function receives `req`, and can be rendered properly.
- [ ] Check that the config list function receives `req`, and can be rendered properly.
- [ ] Check that model creation works.
- [ ] Check that record editing works.
- [ ] Check that record deletion works.
- [ ] Check that config editing works.
- [ ] Read the documentation and make sure it's all okay.
