### PR TITLE
Fix path ckeditor for non /admin admin paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a race condition where `req.linz.model.linz.formtools.form` would be undefined.
 - Fix Linz not being able to find labels for embedded documents.
+- Fix ckeditor for non `/admin` admin paths.
 
 ## v1.0.0-14.0.0 (14 November 2017)
 

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -4,6 +4,8 @@ if (!linz) {
 
 (function  () {
 
+    var adminPath;
+
     $(document).ready(function () {
 
         // javascript events for the navigation
@@ -55,8 +57,8 @@ if (!linz) {
         $('.ckeditor').each(function () {
 
             var editorConfig = {
-                customConfig: $(this).attr('data-linz-ckeditor-config') || '/admin/public/js/ckeditor-config-linz-default.js',
-                contentsCss: $(this).attr('data-linz-ckeditor-style') ? $(this).attr('data-linz-ckeditor-style').split(',') : '/admin/public/css/ckeditor-linz-default.css'
+                customConfig: $(this).attr('data-linz-ckeditor-config') || adminPath + '/public/js/ckeditor-config-linz-default.js',
+                contentsCss: $(this).attr('data-linz-ckeditor-style') ? $(this).attr('data-linz-ckeditor-style').split(',') : adminPath + '/public/css/ckeditor-linz-default.css'
             };
 
             // check if there are any widgets to include
@@ -90,7 +92,7 @@ if (!linz) {
         $('.ckeditor-inline').each(function () {
 
             var editorConfig = {
-                customConfig: $(this).attr('data-linz-ckeditor-config') || '/admin/public/js/ckeditor-config-linz-default.js'
+                customConfig: $(this).attr('data-linz-ckeditor-config') || adminPath + '/public/js/ckeditor-config-linz-default.js'
             };
 
             // check if there are any widgets to include
@@ -170,6 +172,8 @@ if (!linz) {
     });
 
     function loadLibraries(path) {
+
+        adminPath = path;
 
         // resource loader for fallback support
         Modernizr.load([


### PR DESCRIPTION
This PR fixes the ckeditor when using a non `/admin` admin path.

### Setup

- [x] Create a model with the ckeditor.

### Testing

- [x] You should see some errors popup in the browser console.
- [x] Map in this fixed version of Linz.
- [x] The errors should go away.
