### PR TITLE
Documents widget create button label is now configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the ability to set some help text which will appear in a Bootstrap popover, on a model list view.
 - Fix a race condition where `req.linz.model.linz.formtools.form` would be undefined.
 - Fix Linz not being able to find labels for embedded documents.
+- Update the default for the `linz.formtools.widgets.documents` widget create button to be `Create`, and made it configurable by passing in `buttonLabel: 'New label'` to the widget.
 
 ## v1.0.0-14.0.0 (14 November 2017)
 

--- a/lib/formtools/templates/documents.html
+++ b/lib/formtools/templates/documents.html
@@ -3,7 +3,7 @@
 	<template data-linz-template="document-{{name}}">{{{form}}}</template>
 
 	{{#if canCreate}}
-		<a class="btn btn-default" data-toggle="modal" data-document-action="create">Create another</a>
+		<a class="btn btn-default" data-toggle="modal" data-document-action="create">{{buttonLabel}}</a>
 	{{/if}}
 
 	<input type="hidden" name="{{name}}" value="{{json}}" data-linz-conflict-handler="documentArrayConflictHandler" />

--- a/lib/formtools/widgets/documents.js
+++ b/lib/formtools/widgets/documents.js
@@ -12,16 +12,17 @@ module.exports = function (attrs) {
 
         var o = {
             attributes : {
-                type: 'text',
+                'buttonLabel': 'Create',
                 'class': 'form-control',
-                name: name
+                'name': name,
+                'type': 'text',
             },
             label: {
                 label: field.label,
                 attributes: {
-                    'class': 'col-sm-2 control-label'
-                }
-            }
+                    'class': 'col-sm-2 control-label',
+                },
+            },
         };
 
         // add the helpText
@@ -66,6 +67,7 @@ module.exports = function (attrs) {
                 // locals for the template
                 var content,
                     locals = {
+                        buttonLabel: o.attributes.buttonLabel,
                         name: name,
                         label: o.label.label,
                         form: emdeddedDocumentForm.render(),
@@ -73,7 +75,7 @@ module.exports = function (attrs) {
                         canCreate: !(o.attributes.canCreate === false), // defaults to true
                         canEdit: !(o.attributes.canEdit === false), // defaults to true
                         canDelete: !(o.attributes.canDelete === false), // defaults to true
-                        setLabel: o.attributes.setLabel ? o.attributes.setLabel.toString() : undefined
+                        setLabel: o.attributes.setLabel ? o.attributes.setLabel.toString() : undefined,
                     };
 
                 // document array template


### PR DESCRIPTION
Just a quick PR to make button label that appears via the documents widget configurable.

### Testing

- [x] Run a project without this branch being mapped in.
- [x] Review a model with an embedded document in a form.
- [x] Confirm the create button says _Create another_.
- [x] Map in this branch and restart everything. Confirm the button says _Create_, the new default.
- [x] Go to your documents widget and set `buttonLabel` to a string of your choosing.
- [x] Restart everything and confirm that the button has been customised.
