### PR TITLE
Added support for scripts and styles to have a content property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+### Improvements
+
+- Added support for a `content` property when supplying `scripts` and `styles` defaults. Supplying `content` for a script will ensure the content is placed within two script tags (i.e. `<script>{{{content}}}</script>`). Supplying `content` for a style will ensure the content is placed within two style tags (as opposed to using a link tag) (i.e. `<style>{{{content}}}</style>`).
+
 ## v1.0.0-15.0.0 (24 November 2017)
 
-## BREAKING CHANGES
+### BREAKING CHANGES
 
 - The `linz.formtools.widgets.date` and `linz.formtools.widgets.dateRange` are functions which must be executed. Previously you could simply reference them. However, you can pass in a date format which will be used to customise the display of the date in the UI.
 

--- a/docs/defaults.rst
+++ b/docs/defaults.rst
@@ -105,6 +105,8 @@ You should use the existing array as the array that is resolved with the promise
 
 The script objects can contain an additional ``inHead`` boolean option to optionally load the script in the head tag.
 
+You can also supply a ``content`` property, which if provided, will add the value of the ``content`` property within the script open and close tags.
+
 styles
 -------
 
@@ -136,6 +138,8 @@ The function should return an array of objects containing the same HTML attribut
 
 ``res.locals.styles`` contains all the styles used by Linz, be careful when removing/updating these as it could break functionality within Linz.
 You should use the existing array as the array that is resolved with the promise because it will replace ``res.locals.styles``, not append to it.
+
+You can also supply a ``content`` property, which if provided, will add the value of the ``content`` property within a ``style`` open and close tags.
 
 mongoOptions
 ------------

--- a/views/partials/foot.jade
+++ b/views/partials/foot.jade
@@ -1,7 +1,10 @@
 if scripts && scripts.length
 	each script in scripts
 		if !script.inHead
-			script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)
+			if script.content
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)!= script.content
+				else
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)
 script.
 	CKEDITOR.replaceClass = null; // Disable replacing by class
 	CKEDITOR.disableAutoInline = true;

--- a/views/partials/head.jade
+++ b/views/partials/head.jade
@@ -5,8 +5,14 @@ head
 	title= pageTitle
 	if styles && styles.length
 		each style in styles
-			link(as=style.as crossorigin=style.crossorigin href=style.href hreflang=style.hreflang media=style.media rel=style.rel sizes=style.sizes title=style.title type=style.type)
+			if style.content
+				style(media=style.media nonce=style.nonce title=style.title type=style.type)!= style.content
+			else
+				link(as=style.as crossorigin=style.crossorigin href=style.href hreflang=style.hreflang media=style.media rel=style.rel sizes=style.sizes title=style.title type=style.type)
 	if scripts && scripts.length
 		each script in scripts
 			if script.inHead
-				script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)
+				if script.content
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)!= script.content
+				else
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)


### PR DESCRIPTION
Scripts and styles can now have a content property.

### Setup

- [x] Pull down this branch, and map it into your project.

### Testing

- [x] Add a `content` property to a script. Check content is output within `script` tag.
- [x] Add a `content` property to a script that also has `inHead`. Check content is output within `script` tag.
- [x] Add a `content` property to a style. Check content is output within `style` tag.
- [x] Add a `content` property to a style that also has `inHead`. Check it is ignored.
- [x] Read documentation and make sure it all makes sense.

### Notes

- This is useful for adding things like Google Tag Manager and other scripts which require being within a script tag.
