### PR TITLE
Email and tel renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+### Improvements
+
+- Added support for a `content` property when supplying `scripts` and `styles` defaults. Supplying `content` for a script will ensure the content is placed within two script tags (i.e. `<script>{{{content}}}</script>`). Supplying `content` for a style will ensure the content is placed within two style tags (as opposed to using a link tag) (i.e. `<style>{{{content}}}</style>`).
+
 ## v1.0.0-15.0.0 (24 November 2017)
 
-## BREAKING CHANGES
+### BREAKING CHANGES
 
 - The `linz.formtools.widgets.date` and `linz.formtools.widgets.dateRange` are functions which must be executed. Previously you could simply reference them. However, you can pass in a date format which will be used to customise the display of the date in the UI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Improvements
 
 - Added support for a `content` property when supplying `scripts` and `styles` defaults. Supplying `content` for a script will ensure the content is placed within two script tags (i.e. `<script>{{{content}}}</script>`). Supplying `content` for a style will ensure the content is placed within two style tags (as opposed to using a link tag) (i.e. `<style>{{{content}}}</style>`).
+- Added the `linz.formtools.cellRenderers.email` renderer to render an email in an `a` with the `mailto:` protocol.
+- Added the `linz.formtools.cellRenderers.tel` renderer to render a telephone number in an `a` with the `tel:` protocol.
 
 ## v1.0.0-15.0.0 (24 November 2017)
 

--- a/docs/defaults.rst
+++ b/docs/defaults.rst
@@ -105,6 +105,8 @@ You should use the existing array as the array that is resolved with the promise
 
 The script objects can contain an additional ``inHead`` boolean option to optionally load the script in the head tag.
 
+You can also supply a ``content`` property, which if provided, will add the value of the ``content`` property within the script open and close tags.
+
 styles
 -------
 
@@ -136,6 +138,8 @@ The function should return an array of objects containing the same HTML attribut
 
 ``res.locals.styles`` contains all the styles used by Linz, be careful when removing/updating these as it could break functionality within Linz.
 You should use the existing array as the array that is resolved with the promise because it will replace ``res.locals.styles``, not append to it.
+
+You can also supply a ``content`` property, which if provided, will add the value of the ``content`` property within a ``style`` open and close tags.
 
 mongoOptions
 ------------

--- a/lib/formtools/renderers-cell/email.js
+++ b/lib/formtools/renderers-cell/email.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const email = function emailRenderer (val, record, fieldName, model, callback) {
+
+    return callback(null, '<a href="mailto:' + val + '" rel="nofollow">' + val + '</a>');
+
+};
+
+module.exports = email;

--- a/lib/formtools/renderers-cell/index.js
+++ b/lib/formtools/renderers-cell/index.js
@@ -7,8 +7,10 @@ const datetime = require('./datetime');
 const datetimeLocal = require('./datetime-local');
 const documentArray = require('./document-array');
 const defaultRenderer = require('./default');
+const email = require('./email');
 const localDate = require('./local-date');
 const overviewLink = require('./overview-link');
+const tel = require('./tel');
 const text = require('./text');
 const reference = require('./reference');
 const referenceName = require('./reference-name');
@@ -23,8 +25,10 @@ module.exports = {
     datetimeLocal,
     default: defaultRenderer,
     documentarray: documentArray,
+    email,
     localDate,
     overviewLink,
+    tel,
     text,
     reference,
     referenceName,

--- a/lib/formtools/renderers-cell/tel.js
+++ b/lib/formtools/renderers-cell/tel.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const email = function emailRenderer (val, record, fieldName, model, callback) {
+
+    return callback(null, '<a href="tel:' + val + '" rel="nofollow">' + val + '</a>');
+
+};
+
+module.exports = email;

--- a/views/partials/foot.jade
+++ b/views/partials/foot.jade
@@ -1,7 +1,10 @@
 if scripts && scripts.length
 	each script in scripts
 		if !script.inHead
-			script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)
+			if script.content
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)!= script.content
+				else
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)
 script.
 	CKEDITOR.replaceClass = null; // Disable replacing by class
 	CKEDITOR.disableAutoInline = true;

--- a/views/partials/head.jade
+++ b/views/partials/head.jade
@@ -5,8 +5,14 @@ head
 	title= pageTitle
 	if styles && styles.length
 		each style in styles
-			link(as=style.as crossorigin=style.crossorigin href=style.href hreflang=style.hreflang media=style.media rel=style.rel sizes=style.sizes title=style.title type=style.type)
+			if style.content
+				style(media=style.media nonce=style.nonce title=style.title type=style.type)!= style.content
+			else
+				link(as=style.as crossorigin=style.crossorigin href=style.href hreflang=style.hreflang media=style.media rel=style.rel sizes=style.sizes title=style.title type=style.type)
 	if scripts && scripts.length
 		each script in scripts
 			if script.inHead
-				script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)
+				if script.content
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)!= script.content
+				else
+					script(async=script.async crossorigin=script.crossorigin defer=script.defer integrity=script.integrity src=script.src text=script.text type=script.type)


### PR DESCRIPTION
This PR adds email and telephone renderers into Linz.

### Setup

- [x] Pull down this branch and include it in a project.

### Testing

- [x] Create a new field in a model, setting the list renderer to `tel`.
- [x] Test the renderer works as it should.
- [x] Create a new field in a model, setting the list renderer to `email`.
- [x] Test the renderer works as it should.