### PR TITLE
ON HOLD: Query plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # CHANGELOG
 
+## Unreleased
+
+### Improvements
+
+- Added a new static function `findOneDocument` to all models. This works just like the mongoose `findOne` function except it merges all options into a single `options` object parameter.
+- Added a new static function `findDocuments` to all models. This works just like the mongoose `find` function except it merges all options into a single `options` object parameter.
+
 ## v1.0.0-15.0.0 (24 November 2017)
 
-## BREAKING CHANGES
+### BREAKING CHANGES
 
 - The `linz.formtools.widgets.date` and `linz.formtools.widgets.dateRange` are functions which must be executed. Previously you could simply reference them. However, you can pass in a date format which will be used to customise the display of the date in the UI.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,10 +19,11 @@ Linz is quite new and under rapid development. It is used quite successfully in 
    :caption: Developer documentation
 
    getting_started
+   api
    defaults
    models
    permissions
-   api
+   plugins
 
 .. _model-docs:
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -16,6 +16,7 @@ The query plugin extends the mongoose ``find`` and ``findOne`` static methods th
 ``findDocuments`` accepts all mongoose query options within a single options object. Note the defaults in the example.
 
   .. code-block:: javascript
+  
     Model.findDocuments({
         filter: {},
         lean: true,
@@ -26,6 +27,7 @@ The query plugin extends the mongoose ``find`` and ``findOne`` static methods th
 ``findOneDocument`` accepts all mongoose query options within a single options object. Note the defaults in the example.
 
   .. code-block:: javascript
+  
     Model.findOneDocument({
         filter: {},
         lean: true,

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,0 +1,31 @@
+.. highlight:: javascript
+
+.. _plugins-reference:
+
+********
+Plugins
+********
+
+Linz comes with a number of userful mongoose plugins.
+
+model.queryPlugin
+=================
+
+The query plugin extends the mongoose ``find`` and ``findOne`` static methods through the methods ``findDocuments`` and ``findOneDocument``.
+
+``findDocuments`` accepts all mongoose query options within a single options object. Note the defaults in the example.
+
+  Model.findDocuments({
+      filter: {},
+      lean: true,
+      limit: 10,
+      projection: '',
+  })
+
+``findOneDocument`` accepts all mongoose query options within a single options object. Note the defaults in the example.
+
+  Model.findOneDocument({
+      filter: {},
+      lean: true,
+      projection: '',
+  })

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -6,7 +6,7 @@
 Plugins
 ********
 
-Linz comes with a number of userful mongoose plugins.
+Linz comes with a number of useful mongoose plugins.
 
 model.queryPlugin
 =================
@@ -15,17 +15,19 @@ The query plugin extends the mongoose ``find`` and ``findOne`` static methods th
 
 ``findDocuments`` accepts all mongoose query options within a single options object. Note the defaults in the example.
 
-  Model.findDocuments({
-      filter: {},
-      lean: true,
-      limit: 10,
-      projection: '',
-  })
+  .. code-block:: javascript
+    Model.findDocuments({
+        filter: {},
+        lean: true,
+        limit: 10,
+        projection: '',
+    })
 
 ``findOneDocument`` accepts all mongoose query options within a single options object. Note the defaults in the example.
 
-  Model.findOneDocument({
-      filter: {},
-      lean: true,
-      projection: '',
-  })
+  .. code-block:: javascript
+    Model.findOneDocument({
+        filter: {},
+        lean: true,
+        projection: '',
+    })

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -216,7 +216,11 @@ module.exports = function formtoolsPlugin (schema, options) {
     // defined get data function
     schema.statics.getObject = function (id, cb) {
 
-        return this.findById(id, cb);
+        return this.findOneDocument({
+            filter: { _id: id },
+            lean: false,
+            projection: '*',
+        }).exec(cb);
 
     };
 

--- a/lib/formtools/renderers-cell/reference-name.js
+++ b/lib/formtools/renderers-cell/reference-name.js
@@ -4,11 +4,19 @@ const linz = require('../../../');
 
 const referenceName = function referenceNameRenderer (val, record, fieldName, model, callback) {
 
-    linz.mongoose.models[model.schema.tree[fieldName].ref].findById(val, function (err, doc) {
+    linz.mongoose.models[model.schema.tree[fieldName].ref].findOneDocument({
+        filter: { _id: val },
+        projection: 'title',
+    })
+        .exec(function (err, doc) {
 
-        return callback(null, (doc) ? doc.title : ((val && val.length) ? val + ' (missing)' : ''));
+            if (err) {
+                return callback(err);
+            }
 
-    });
+            return callback(null, (doc) ? doc.title : ((val && val.length) ? val + ' (missing)' : ''));
+
+        });
 
 };
 

--- a/lib/formtools/renderers-cell/reference-value.js
+++ b/lib/formtools/renderers-cell/reference-value.js
@@ -10,11 +10,19 @@ const referenceValue = function referenceValueRenderer (val, record, fieldName, 
 
     }
 
-    linz.mongoose.models[val.ref].findById(val._id, function (err, doc) {
+    linz.mongoose.models[val.ref].findOneDocument({
+        filter: { _id: val._id },
+        projection: 'title',
+    })
+        .exec(function (err, doc) {
 
-        return callback(null, (doc) ? doc.title : ((val && val.length) ? val + ' (missing)' : ''));
+            if (err) {
+                return callback(err);
+            }
 
-    });
+            return callback(null, (doc) ? doc.title : ((val && val.length) ? val + ' (missing)' : ''));
+
+        });
 
 };
 

--- a/lib/formtools/renderers-cell/reference.js
+++ b/lib/formtools/renderers-cell/reference.js
@@ -12,11 +12,10 @@ const reference = function referenceRenderer (val, record, fieldName, model, cal
     // `val` and `record` could be arrays...
     if (Array.isArray(val)) {
 
-        return linz.mongoose.models[model.schema.tree[fieldName].ref].find({
-            '_id': {
-                '$in': val
-            }
-        }, (err, docs) => {
+        return linz.mongoose.models[model.schema.tree[fieldName].ref].findDocuments({
+            filter: { _id: { $in: val } },
+            projection: 'title',
+        }).exec((err, docs) => {
 
             // Return an object, indexed by `_id`.
             // There is no guarantee the results will be returned in the same order

--- a/lib/formtools/renderers-cell/reference.js
+++ b/lib/formtools/renderers-cell/reference.js
@@ -35,7 +35,10 @@ const reference = function referenceRenderer (val, record, fieldName, model, cal
     }
 
     // Not an array, just a single value.
-    linz.mongoose.models[model.schema.tree[fieldName].ref].findById(val, function (err, doc) {
+    linz.mongoose.models[model.schema.tree[fieldName].ref].findOneDocument({
+        filter: { _id: val },
+        projection: 'title',
+    }).exec(function (err, doc) {
 
         return callback(err, (doc) ? doc.title : ((val && val.length) ? val + ' (missing)' : ''));
 

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -21,7 +21,11 @@ module.exports = function (pp) {
 
 		var users = linz.mongoose.model(linz.get('user model'));
 
-		users.findById(id).exec(done);
+		users.findOneDocument({
+            filter: { _id: id },
+            lean: false,
+            projection: '*',
+        }).exec(done);
 
 	});
 

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -33,8 +33,12 @@ module.exports = function (pp) {
 
 		find[linz.get('username key')] = username;
 
-
-	    users.findOne(find).exec(function (err, user) {
+        // Don't use lean here as it causes issues with some passport methods.
+	    users.findOneDocument({
+            filter: find,
+            lean: false,
+            projection: '*',
+        }).exec(function (err, user) {
 
 			if (err) {
 				debugSession('Login error: ' + err);

--- a/lib/versions/renderers/overview.js
+++ b/lib/versions/renderers/overview.js
@@ -10,9 +10,11 @@ module.exports = function versionsRenderer (req, res, record, model, settings, c
         // get a list of all the versions from the archived
         function (cb) {
 
-            model.VersionedModel.find({ refId: record._id }, 'dateCreated modifiedBy', { lean: 1, sort: { dateCreated: -1 } }, function (err, result) {
-                return cb(err, result);
-            });
+            model.VersionedModel.findDocuments({
+                filter: { refId: record._id },
+                projection: 'dateCreated modifiedBy',
+                sort: { dateCreated: -1 },
+            }).exec(cb);
 
         }
 

--- a/linz.js
+++ b/linz.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { deprecate } = require('util');
+const { queryPlugin } = require('./plugins/model');
 
 /**
  * Load required modules
@@ -176,6 +177,19 @@ Linz.prototype.init = function (opts = {}) {
 };
 
 /**
+ * Register some Linz plugins.
+ * @param {Object} mongooseInstance The Linz mongoose instance.
+ * @param {Function} callback Callback function.
+ */
+Linz.prototype.registerPlugins = (mongooseInstance, callback) => {
+
+    mongooseInstance.plugin(queryPlugin);
+
+    return callback();
+
+};
+
+/**
 * Initialize the application
 *
 * @api private
@@ -239,6 +253,10 @@ Linz.prototype.configure = function() {
 
             }, 100);
 
+        },
+
+        function (cb) {
+            return _this.registerPlugins(_this.mongoose, cb);
         },
 
         function (cb) {

--- a/middleware/_modelVersionsCompare.js
+++ b/middleware/_modelVersionsCompare.js
@@ -92,7 +92,10 @@ module.exports = function (req) {
 
     var getVersionById = (id, projection, bRenderFields, cb) => {
 
-        Model.VersionedModel.findById(id, projection, { lean: 1 }, (err, record) => {
+        Model.VersionedModel.findOneDocument({
+            filter: { _id: id },
+            projection,
+        }).exec((err, record) => {
 
             if (err) {
                 return cb(err);

--- a/middleware/modelVersionsRollback.js
+++ b/middleware/modelVersionsRollback.js
@@ -13,9 +13,16 @@ module.exports = {
         async.series({
 
             latest: function (cb) {
-                Model.findById(req.params.id, cb);
+
+                Model.findOneDocument({
+                    filter: { _id: req.params.id },
+                    lean: false,
+                    projection: '*',
+                }).exec(cb);
+
             },
             previous: function (cb) {
+
                 var exclusions = { '_id': 0, '__v': 0, 'refId': 0, 'refVersion': 0, 'dateModified': 0, 'dateCreated': 0, 'createdBy': 0, 'modifiedBy': 0 };
 
                 if (Model.versions.ignorePaths && Model.versions.ignorePaths.length) {
@@ -24,7 +31,11 @@ module.exports = {
                     });
                 }
 
-                Model.VersionedModel.findById(req.params.revisionAId, exclusions, { lean: 1 }, cb);
+                Model.VersionedModel.findOneDocument({
+                    filter: { _id: req.params.revisionAId },
+                    projection: exclusions,
+                }).exec(cb);
+
             }
 
         }, function (err, result) {

--- a/middleware/passwordReset.js
+++ b/middleware/passwordReset.js
@@ -12,7 +12,11 @@ module.exports = {
 
         var User = linz.api.model.get(linz.get('user model'));
 
-        User.findById(req.params.id, function (err, doc) {
+        User.findOneDocument({
+            filter: { _id: req.params.id },
+            lean: false,
+            projection: '*',
+        }).exec(function (err, doc) {
 
             if (err) {
                 return next(err);

--- a/middleware/recordChange.js
+++ b/middleware/recordChange.js
@@ -158,7 +158,10 @@ module.exports = function (req, res, next) {
 
 		function (cb) {
 
-			Model.findById(req.params.id, exclusionFields, { lean: 1 }, function (err, doc) {
+            Model.findOneDocument({
+                filter: { _id: req.params.id },
+                projection: exclusionFields,
+            }).exec(function (err, doc) {
 
 				if (err) {
 					return cb(err);

--- a/plugins/model.js
+++ b/plugins/model.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Assign some defaults to the passed Mongoose query options.
+ * @example
+ * // returns {
+ *     filter: { _id: id },
+ *     lean: true,
+ *     limit: 10,
+ *     projection: '',
+ * }
+ * getOptions({ filter: { _id: id });
+ * @param {Object} options Mongoose query options.
+ * @param {Object} options.filter Mongo query filters.
+ * @param {Boolean} options.lean Whether to return a plain JavaScript object or not.
+ * @param {Number} options.limit Number of documents to return.
+ * @param {String} options.projection Space delimited string containing the fields to return or '*' to return all fields.
+ * @return {Object} Returns the options object for Mongoose queries.
+ */
+const getOptions = (options) => {
+
+    const defaults = {
+        filter: {},
+        lean: true,
+        limit: 10,
+        projection: '_id',
+    };
+
+    Object.assign(defaults, options);
+
+    // * must be passed to return all fields.
+    if (options.projection === '*') {
+        delete defaults.projection;
+    }
+
+    return defaults;
+
+};
+
+/**
+ * Extend the build in mongoose queries.
+ * @param {Object} schema The mongoose schema.
+ * @param {Object} options The plugin options.
+ * @return {Void} Sets up the methods.
+ */
+const queryPlugin = (schema, options) => {
+
+    /**
+     * Find documents from a model.
+     * @example
+     * Model.findDocuments({
+     *     filter: { _id: id },
+     *     projection: 'email username', // _id is always returned
+     * });
+     * @param {Object} options Mongoose query options.
+     * @param {Object} options.filter Mongo query filters.
+     * @param {String} options.projection Space delimited string containing the fields to return or '*' to return all fields.
+     * @return {Promise} Returns a Mongoose query.
+     */
+    schema.statics.findDocuments = function findDocuments (options) {
+
+        const { filter, projection } = getOptions(options);
+
+        return this.find(filter, projection, getOptions(options));
+
+    };
+
+    /**
+     * Find one document from a model.
+     * @example
+     * Model.findOneDocument({
+     *     filter: { _id: id },
+     *     projection: 'email username', // _id is always returned
+     * });
+     * @param {Object} options Mongoose query options.
+     * @param {Object} options.filter Mongo query filters.
+     * @param {String} options.projection Space delimited string containing the fields to return or '*' to return all fields.
+     * @return {Promise} Returns a Mongoose query.
+     */
+    schema.statics.findOneDocument = function findOneDocument (options) {
+
+        const { filter, projection } = getOptions(options);
+
+        return this.findOne(filter, projection, getOptions(options));
+
+    };
+
+};
+
+module.exports = { queryPlugin };

--- a/plugins/model.js
+++ b/plugins/model.js
@@ -40,10 +40,9 @@ const getOptions = (options) => {
 /**
  * Extend the build in mongoose queries.
  * @param {Object} schema The mongoose schema.
- * @param {Object} options The plugin options.
  * @return {Void} Sets up the methods.
  */
-const queryPlugin = (schema, options) => {
+const queryPlugin = (schema) => {
 
     /**
      * Find documents from a model.

--- a/routes/recordDelete.js
+++ b/routes/recordDelete.js
@@ -3,33 +3,34 @@ var linz = require('../');
 /* GET /admin/:model/:id/delete */
 var route = function (req, res, next) {
 
-	req.linz.model.findOne({_id: req.linz.record._id}, function (err, doc) {
+    req.linz.model.findOneDocument({ filter: { _id: req.linz.record._id } })
+        .exec(function (err, doc) {
 
-        if (err) {
-            return next(err);
-        }
-
-        // Skip to a 404 page.
-        if (!doc) {
-            return next();
-        }
-
-        if (!doc) {
-		  return res.redirect(linz.api.url.getAdminLink(req.linz.model));
-        }
-
-        doc.remove(function (removeErr) {
-
-            if (removeErr) {
-                return next(removeErr);
+            if (err) {
+                return next(err);
             }
 
+            // Skip to a 404 page.
+            if (!doc) {
+                return next();
+            }
+
+            if (!doc) {
             return res.redirect(linz.api.url.getAdminLink(req.linz.model));
+            }
+
+            doc.remove(function (removeErr) {
+
+                if (removeErr) {
+                    return next(removeErr);
+                }
+
+                return res.redirect(linz.api.url.getAdminLink(req.linz.model));
+
+            });
+
 
         });
-
-
-	});
 
 };
 

--- a/routes/recordJSON.js
+++ b/routes/recordJSON.js
@@ -3,7 +3,10 @@
 var route = function (req, res, next) {
 
     // get doc
-    req.linz.model.findById(req.params.id, function (err, doc) {
+    req.linz.model.findOneDocument({
+        filter: { _id: req.params.id },
+        projection: '*',
+    }).exec(function (err, doc) {
 
         if (err) {
             return next(err);

--- a/routes/recordSave.js
+++ b/routes/recordSave.js
@@ -12,7 +12,11 @@ var route = function (req, res, next) {
 
         function (done) {
 
-            req.linz.model.findById(req.params.id).exec(function (err, record) {
+            req.linz.model.findOneDocument({
+                filter: { _id: req.params.id },
+                lean: false,
+                projection: '*',
+            }).exec(function (err, record) {
 
                 if (err) {
                     return next(err);

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -1445,7 +1445,7 @@ describe('formtools', function () {
 
                         it('should render date range input fields with form values', function () {
                             var fieldName = 'dateCreated',
-                                filterDates = { dateCreated: { dateFrom: [moment('2014-05-16', 'YYYY-MM-DD').zone('+0:00').toISOString()], dateTo: [moment('2014-05-17', 'YYYY-MM-DD').endOf('day').zone('+0:00').toISOString()] } };
+                                filterDates = { dateCreated: { dateFrom: [moment('2014-05-16', 'YYYY-MM-DD').startOf('day').toISOString()], dateTo: [moment('2014-05-17', 'YYYY-MM-DD').endOf('day').toISOString()] } };
 
                             linz.formtools.filters.dateRange().bind(fieldName, filterDates, function (err, result) {
                                 result.should.be.instanceof(Array).and.have.lengthOf(1);
@@ -1462,7 +1462,7 @@ describe('formtools', function () {
 
                             linz.formtools.filters.dateRange(dateFormat).bind(fieldName, filterDates, function (err, result) {
                                 result.should.be.instanceof(Array).and.have.lengthOf(1);
-                                result[0].should.equal('<input type="text" name="' + fieldName + '[dateFrom][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="DD.MM.YYYY" data-linz-date-value="' + utcDates.dateCreated.dateFrom[0] + '" required><input type="text" name="' + fieldName + '[dateTo][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="DD.MM.YYYY" data-linz-date-value="2014-05-15T23:59:59.999Z" required>');
+                                result[0].should.equal('<input type="text" name="' + fieldName + '[dateFrom][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="DD.MM.YYYY" data-linz-date-value="' + utcDates.dateCreated.dateFrom[0] + '" required><input type="text" name="' + fieldName + '[dateTo][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="DD.MM.YYYY" data-linz-date-value="' + utcDates.dateCreated.dateTo[0] + '" required>');
                             });
 
                         });
@@ -1476,8 +1476,8 @@ describe('formtools', function () {
 
                             linz.formtools.filters.dateRange().bind(fieldName, filterDates, function (err, result) {
                                 result.should.be.instanceof(Array).and.have.lengthOf(2);
-                                result[0].should.equal('<input type="text" name="' + fieldName + '[dateFrom][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="' + utcDates.dateCreated.dateFrom[0] + '" required><input type="text" name="' + fieldName + '[dateTo][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="2014-05-17T23:59:59.999Z" required>');
-                                result[1].should.equal('<input type="text" name="' + fieldName + '[dateFrom][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="' + utcDates.dateCreated.dateFrom[1] + '" required><input type="text" name="' + fieldName + '[dateTo][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="2014-05-19T23:59:59.999Z" required>');
+                                result[0].should.equal('<input type="text" name="' + fieldName + '[dateFrom][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="' + utcDates.dateCreated.dateFrom[0] + '" required><input type="text" name="' + fieldName + '[dateTo][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="' + utcDates.dateCreated.dateTo[0] + '" required>');
+                                result[1].should.equal('<input type="text" name="' + fieldName + '[dateFrom][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="' + utcDates.dateCreated.dateFrom[1] + '" required><input type="text" name="' + fieldName + '[dateTo][]" class="form-control" data-ui-datepicker="true" data-linz-date-format="YYYY-MM-DD" data-linz-date-value="' + utcDates.dateCreated.dateTo[1] + '" required>');
                             });
                         });
 

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -1349,7 +1349,7 @@ describe('formtools', function () {
                         });
 
                         it('should render multiple date input fields with form values if there are multiple filters on the same field', function (done) {
-                            
+
                             var fieldName = 'dateCreated';
                             var dateFormat = 'YYYY-MM-DD';
                             var dateFromString = '2014-05-16';
@@ -1415,7 +1415,7 @@ describe('formtools', function () {
                         });
 
                         it('should support a custom date format', function () {
-                            
+
                             var fieldName = 'dateCreated',
                                 filterDates = ['16.05.2014'];
                             linz.formtools.filters.date('DD.MM.YYYY').filter(fieldName, { 'dateCreated': filterDates }, function (err, result) {
@@ -1544,7 +1544,7 @@ describe('formtools', function () {
                             linz.formtools.filters.dateRange('DD.MM.YYYY').filter(fieldName, filterDates, function (err, result) {
                             result.should.have.property(fieldName, { $gte: moment(filterDates.dateCreated.dateFrom[0], 'DD.MM.YYYY').startOf('day').toISOString(), $lte: moment(filterDates.dateCreated.dateTo[0], 'DD.MM.YYYY').endOf('day').toISOString() });
                             });
-                            
+
                         });
 
                     });
@@ -1958,10 +1958,7 @@ describe('formtools', function () {
                     });
 
                     it('should execute the query in mongoose find() with no error', function (done) {
-                        OverridesPostModel.find(result, function (err) {
-                            (err === null).should.be.true;
-                            done();
-                        });
+                        return OverridesPostModel.findDocuments({ filter: result });
                     });
 
                 });

--- a/test/formtools.js
+++ b/test/formtools.js
@@ -1,5 +1,7 @@
 /* eslint-env mocha */
 
+const { queryPlugin } = require('../plugins/model');
+
 var linz = require('../linz'),
     moment = require('moment');
 
@@ -30,6 +32,8 @@ User.singular = 'User';
 var mongoose = linz.mongoose,
 	formtools = linz.formtools,
     async = require('async');
+
+linz.mongoose.plugin(queryPlugin);
 
 describe('formtools', function () {
 
@@ -1957,8 +1961,8 @@ describe('formtools', function () {
 
                     });
 
-                    it('should execute the query in mongoose find() with no error', function (done) {
-                        return OverridesPostModel.findDocuments({ filter: result });
+                    it('should execute the query in mongoose find() with no error', function () {
+                        OverridesPostModel.findDocuments({ filter: result }).exec();
                     });
 
                 });


### PR DESCRIPTION
## Update

I think we should hold off on merging this in until https://github.com/linzjs/linz/issues/193 is done. We can then create a new repo for it and use it there.

This PR adds a new global query plugin that adds the static functions `findOneDocument` and `findDocuments` to all models.

### Setup

- [ ] Map in this version of Linz.

### Testing

- [ ] Update your model queries to use `findOneDocument` and `findDocuments`.
