### PR TITLE
Only default to descending with date fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+## Improvements
+
+- You can now supply a `defaultOrder` for `sortBy` property of the List DSL.
+- Ascending/descending options are directly listed in the sorting dropdown for each field in the `sortBy` array.
+
 ## v1.0.0-15.1.0 (22 March 2018)
 
 ### Bugs

--- a/docs/models_list.rst
+++ b/docs/models_list.rst
@@ -224,11 +224,21 @@ list.sortBy
 
 ``list.sortBy`` is used to customise the sort field(s) which the data in the model index will be retrieved with.
 
-``list.sortBy`` should be Array of field names, for example::
+``list.sortBy`` should be Array of field names or objects. If using an object, the field property is required for example::
 
-  sortBy: ['name', 'username']
+  sortBy: [
+    'name',
+    'username',
+    {
+      defaultOrder: 'asc',
+      field: 'dateModified',
+      label: 'Date modified',
+    },
+  ]
 
 This Array will be used to populate a drop-down list on the model index. The user can choose an option from the drop-down to sort the list with.
+
+The ``defaultOrder`` property is used to set the default ordering of the sort. You may want to change it to ``desc`` when you want the latest records first.
 
 list.toolbarItems
 =================

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -533,10 +533,18 @@ var transformSortBy = function (labels, sortBy) {
 
     return sortBy.map(function (fieldName) {
 
-        return {
+        const defaults = {
+            defaultOrder: 'asc',
             label: (labels[fieldName] || fieldName),
-            field: fieldName
+            field: fieldName,
         };
+
+        // Add the ability to pass an object.
+        if (typeof fieldName !== 'string') {
+            return Object.assign({}, defaults, fieldName);
+        }
+
+        return defaults;
 
     });
 

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -68,7 +68,10 @@ var listDefaults = function (list, labels, titleField) {
     // defaults to true
     list.showSummary = !(list.showSummary === false);
 
-    list.sortBy = transformSortBy(labels, list.sortBy || ['dateModified']);
+    list.sortBy = transformSortBy(labels, list.sortBy || [{
+        defaultOrder: 'desc',
+        field: 'dateModified',
+    }]);
 
     // Will accept an object of Bootstrap popover options.
     list.help = list.help ? list.help : false;

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -533,18 +533,26 @@ var transformSortBy = function (labels, sortBy) {
 
     return sortBy.map(function (fieldName) {
 
-        const defaults = {
+        // Add the ability to pass an object.
+        if (typeof fieldName !== 'string') {
+
+            if (!fieldName.field) {
+                throw new Error('You must provide a field');
+            }
+
+            return Object.assign({}, {
+                defaultOrder: 'asc',
+                label: (labels[fieldName.field] || fieldName.label),
+                field: fieldName.field,
+            }, fieldName);
+
+        }
+
+        return {
             defaultOrder: 'asc',
             label: (labels[fieldName] || fieldName),
             field: fieldName,
         };
-
-        // Add the ability to pass an object.
-        if (typeof fieldName !== 'string') {
-            return Object.assign({}, defaults, fieldName);
-        }
-
-        return defaults;
 
     });
 

--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -351,10 +351,12 @@ module.exports = function  (req, res, next) {
 
                 if (!session.list.formData.sort && req.linz.model.list.sortBy.length) {
 
+                    const defaultOrder = req.linz.model.schema.paths[req.linz.model.list.sortingBy.field].instance === 'Date' ? '-' : '';
+
                     req.linz.model.list.sortingBy = req.linz.model.list.sortBy[0];
 
                     // set default form sort
-                    session.list.formData.sort = `-${req.linz.model.list.sortingBy.field}`;
+                    session.list.formData.sort = `${defaultOrder}${req.linz.model.list.sortingBy.field}`;
 
                 } else {
 

--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -349,21 +349,25 @@ module.exports = function  (req, res, next) {
             // find the docs
             function (cb) {
 
-                if (!session.list.formData.sort && req.linz.model.list.sortBy.length) {
+                const getDefaultOrder = field => field.defaultOrder.toLowerCase() === 'desc' ? '-' : '';
 
-                    const defaultOrder = req.linz.model.schema.paths[req.linz.model.list.sortingBy.field].instance === 'Date' ? '-' : '';
+                if (!session.list.formData.sort && req.linz.model.list.sortBy.length) {
 
                     req.linz.model.list.sortingBy = req.linz.model.list.sortBy[0];
 
                     // set default form sort
-                    session.list.formData.sort = `${defaultOrder}${req.linz.model.list.sortingBy.field}`;
+                    session.list.formData.sort = `${getDefaultOrder(req.linz.model.list.sortingBy)}${req.linz.model.list.sortingBy.field}`;
 
                 } else {
 
                     req.linz.model.list.sortBy.forEach(function (sort) {
+
+                        sort.field = `${getDefaultOrder(sort.defaultOrder)}${sort.field}`;
+
                         if (sort.field === session.list.formData.sort || '-' + sort.field === session.list.formData.sort) {
                             req.linz.model.list.sortingBy = sort;
                         }
+
                     });
 
                 }

--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -362,8 +362,6 @@ module.exports = function  (req, res, next) {
 
                     req.linz.model.list.sortBy.forEach(function (sort) {
 
-                        sort.field = `${getDefaultOrder(sort.defaultOrder)}${sort.field}`;
-
                         if (sort.field === session.list.formData.sort || '-' + sort.field === session.list.formData.sort) {
                             req.linz.model.list.sortingBy = sort;
                         }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "linz.js",
   "scripts": {
     "pretest": "./test/scripts/pretest.sh",
-    "test": "./node_modules/.bin/jest --forceExit"
+    "test": "./node_modules/.bin/jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "linz.js",
   "scripts": {
     "pretest": "./test/scripts/pretest.sh",
-    "test": "./node_modules/.bin/jest"
+    "test": "./node_modules/.bin/jest --forceExit"
   },
   "repository": {
     "type": "git",

--- a/routes/modelIndex.js
+++ b/routes/modelIndex.js
@@ -27,7 +27,8 @@ var route = function (req, res, next) {
                 page = Number(req.linz.records.page),
                 pages = Number(req.linz.records.pages),
                 to = pageSize*page,
-                sortDirection = '';
+                sortDirection = '',
+                form = req.linz.model.formData || {};
 
             if (to > total) {
                 to = total;
@@ -54,9 +55,38 @@ var route = function (req, res, next) {
             // Remove the primary record actions, from the standard ones.
             req.linz.model.list.recordActions = req.linz.model.list.recordActions.filter(action => action.type !== 'primary');
 
+            // Work through the sorting options.
+            const sortingOptions = [];
+
+            req.linz.model.list.sortBy.forEach(function (sortBy) {
+
+                const sort = form.sort.replace('/^-/', '');
+
+                // Don't display ascending, if it's already sorting ascending on this field.
+                if (sort.toLowerCase() != sortBy.field.toLowerCase()) {
+
+                    sortingOptions.push({
+                        label: `${sortBy.label} <em>(ascending)</em>`,
+                        value: `${sortBy.field}`,
+                    });
+
+                }
+
+                // Don't display descending, if it's already sorting descending on this field.
+                if (form.sort.toLowerCase() !== `-${sortBy.field}`.toLowerCase()) {
+
+                    sortingOptions.push({
+                        label: `${sortBy.label} <em>(descending)</em>`,
+                        value: `-${sortBy.field}`,
+                    });
+
+                }
+
+            });
+
             const data = {
                 customAttributes: res.locals.customAttributes,
-                form: req.linz.model.formData || {},
+                form,
                 from: pageSize*page-pageSize,
                 help: req.linz.model.list.help,
                 label: {
@@ -65,19 +95,20 @@ var route = function (req, res, next) {
                 },
                 model: req.linz.model,
                 modelQuery: JSON.stringify(req.linz.model.formData),
-                page: page,
-                pages: pages,
+                page,
+                pages,
                 pageTitle: req.linz.model.linz.formtools.model.plural,
-                pageSize: pageSize,
+                pageSize,
                 pageSizes: req.linz.model.list.paging.sizes || linz.get('page sizes'),
                 pagination: req.linz.model.list.paging.active === true,
                 permissions: req.linz.model.linz.formtools.permissions,
                 query: req.query,
                 records: req.linz.records.records,
                 sort: req.linz.model.list.sortingBy,
-                sortDirection: sortDirection,
-                to: to,
-                total: total,
+                sortDirection,
+                sortingOptions,
+                to,
+                total,
                 scripts,
                 styles,
                 user: req.user,

--- a/test/formtools.test.js
+++ b/test/formtools.test.js
@@ -1121,14 +1121,17 @@ describe('formtools', () => {
 
                         expect(overridesListOpts.sortBy).toEqual([
                             {
+                                defaultOrder: 'asc',
                                 label: 'First Name',
                                 field: 'firstName'
                             },
                             {
+                                defaultOrder: 'asc',
                                 label: 'lastName',
                                 field: 'lastName'
                             },
                             {
+                                defaultOrder: 'asc',
                                 label: 'Date modified',
                                 field: 'dateModified'
                             }

--- a/views/modelIndex/sorting.jade
+++ b/views/modelIndex/sorting.jade
@@ -8,10 +8,11 @@
 				for sortField in model.list.sortBy
 					li
 						a(data-sort-field='' + sortField.field + '')
-							if '-' + sortField.field === form.sort
-								!= sortField.label + ' <em>(ascending)</em>'
-							else if sortField.field === form.sort
-								!= sortField.label + ' <em>(descending)</em>'
+							if '-' + sortField.field === form.sort || sortField.field === form.sort
+								if sortDirection === sortField.defaultOrder
+									!= sortField.label + ' <em>(' + ((sortDirection === 'asc') ? 'descending' : 'ascending') + ')</em>'
+								else
+									!= sortField.label
 							else
 								!= sortField.label
 		.direction= ((sortDirection === 'asc') ? 'ascending' : 'descending')

--- a/views/modelIndex/sorting.jade
+++ b/views/modelIndex/sorting.jade
@@ -5,16 +5,10 @@
 			.field(data-toggle='dropdown')= sort.label
 				span.caret
 			ul.dropdown-menu(role='menu')
-				for sortField in model.list.sortBy
+				for sortingOption in sortingOptions
 					li
-						a(data-sort-field='' + sortField.field + '')
-							if '-' + sortField.field === form.sort || sortField.field === form.sort
-								if sortDirection === sortField.defaultOrder
-									!= sortField.label + ' <em>(' + ((sortDirection === 'asc') ? 'descending' : 'ascending') + ')</em>'
-								else
-									!= sortField.label
-							else
-								!= sortField.label
+						a(data-sort-field='' + sortingOption.value + '')
+							!= sortingOption.label
 		.direction= ((sortDirection === 'asc') ? 'ascending' : 'descending')
 	else
 		div #{total} records.


### PR DESCRIPTION
This PR adds the ability to provide an object or string for the sortby array.

Signed-off-by: Allan Chau <allan.chau@icloud.com>

### Setup

- [x] Create a model with a String and object in the sortby array. 

```javascript
module.exports = [
    'title',
    'description',
    {
        defaultOrder: 'desc', // Chronological order
        field: 'dateModified',
        label: 'Date modified',
    },
];
```

### Testing

- [ ] Using the example above, sort by the title. When the current sorting is **NOT** the default there should be no `descending` or `ascending` text.
- [ ] Filter on the dateModified field. It should default to descending.
- [ ] View the sorting list and it should say `Date modfied (ascending)`
