### PR TITLE
Improved the model index for when no records can be found

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 indent_size = 4
 
 [*.jade]
-indent_style = tab
+indent_style = space
 indent_size = 4
 
 [Makefile]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - You can now supply a `defaultOrder` for `sortBy` property of the List DSL.
 - Ascending/descending options are directly listed in the sorting dropdown for each field in the `sortBy` array.
+- When the model index can't find any records for the current query, the model index now shows the words "No records found", and removes sorting and paging controls.
 
 ## v1.0.0-15.1.0 (22 March 2018)
 

--- a/routes/modelIndex.js
+++ b/routes/modelIndex.js
@@ -60,10 +60,11 @@ var route = function (req, res, next) {
 
             req.linz.model.list.sortBy.forEach(function (sortBy) {
 
-                const sort = form.sort.replace('/^-/', '');
+                const sort = form.sort || '';
+                const sortFieldName = sort.replace('/^-/', '');
 
                 // Don't display ascending, if it's already sorting ascending on this field.
-                if (sort.toLowerCase() != sortBy.field.toLowerCase()) {
+                if (sortFieldName.toLowerCase() != sortBy.field.toLowerCase()) {
 
                     sortingOptions.push({
                         label: `${sortBy.label} <em>(ascending)</em>`,
@@ -73,7 +74,7 @@ var route = function (req, res, next) {
                 }
 
                 // Don't display descending, if it's already sorting descending on this field.
-                if (form.sort.toLowerCase() !== `-${sortBy.field}`.toLowerCase()) {
+                if (sort.toLowerCase() !== `-${sortBy.field}`.toLowerCase()) {
 
                     sortingOptions.push({
                         label: `${sortBy.label} <em>(descending)</em>`,

--- a/views/modelIndex.jade
+++ b/views/modelIndex.jade
@@ -10,9 +10,12 @@ block content
                 .row
                     .col-xs-12
                         include modelIndex/filters
-                        if model.list.showSummary
-                            include modelIndex/sorting
-                            include modelIndex/paging
+                        if records.length > 0
+                            if model.list.showSummary
+                                include modelIndex/sorting
+                                include modelIndex/paging
+                        else
+                            include modelIndex/no-records
 
             if records.length > 0
                 block main-content

--- a/views/modelIndex/no-records.jade
+++ b/views/modelIndex/no-records.jade
@@ -1,0 +1,2 @@
+.model-sort
+    div No records found.


### PR DESCRIPTION
As per the title, this improves the model index for when no records are found. Changelog contains all the details.

### Setup

- [x] Pull down this PR and integrate into a project.

### Testing

- [x] View the model index on a model with records. It should be all fine.
- [x] View the model index on a model with no records. You should see the words "No records found".
