### PR TITLE
WIP: Fix document array error when using the default renderer

### DIFF
--- a/lib/formtools/renderers-cell/default.js
+++ b/lib/formtools/renderers-cell/default.js
@@ -3,7 +3,6 @@
 const array = require('./array');
 const boolean = require('./boolean');
 const date = require('./date');
-const documentArray = require('./document-array');
 const linz = require('../../../');
 const localDate = require('./local-date');
 const reference = require('./reference');
@@ -25,6 +24,8 @@ const defaultRenderer = function defaultRenderer (val, record, fieldName, model,
 
         // check if this field is a document array
         if (Array.isArray(model.schema.tree[fieldName])) {
+
+            const documentArray = require('./document-array');
 
             return documentArray(val, record, fieldName, model, callback);
 


### PR DESCRIPTION
This PR fixes a rare case where using the default renderer on a document array field will result in a document array is not a function error.

### Setup

- [ ] A list of steps to get started with testing.

### Testing

- [ ] All the steps required to complete testing the PR.

### Notes

- Any additional notes you think will be useful.
