### PR TITLE
Enabled primary record actions with a modal (on model index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Added support primary record actions with a modal on the model index.
+
 ## v1.0.0-16.2.0 (5 December 2018)
 
 - Added a new default `routes`, which allows you to define middleware to be executed during the processing of a Linz route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.0-16.2.1 (18 December 2018)
 
-- Added support primary record actions with a modal on the model index.
+- Added support for primary record actions with a modal on the model index.
 
 ## v1.0.0-16.2.0 (5 December 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v1.0.0-16.2.1 (18 December 2018)
 
 - Added support primary record actions with a modal on the model index.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-16.2.0",
+  "version": "1.0.0-16.2.1",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",

--- a/views/partials/action-record.jade
+++ b/views/partials/action-record.jade
@@ -24,7 +24,11 @@ div.btn-group
                 if action.icon
                     span(class='glyphicon glyphicon-' + action.icon)
         else
-            a.btn.btn-default(href=linz.api.url.getAdminLink(model, action.action, record._id), data-linz-control="primary")
+            - action.attributes = action.attributes || {}
+            if action.modal.active
+                - action.attributes['data-linz-control'] = 'record-action'
+                - action.attributes['data-target'] = '#recordActionModal'
+            a.btn.btn-default(href=linz.api.url.getAdminLink(model, action.action, record._id) data-linz-control="primary" class=(action.modal.active && 'disabled'))&attributes(action.attributes)
                 if !action.icon
                     != action.label
                 if action.icon


### PR DESCRIPTION
Linz had a bug where if you used the following combination (specifically primary and modal) on a record action, the modal part never worked.

```JavaScript
actions.push({
            action: 'delete-team',
            icon: 'trash',
            label: 'Delete',
            modal: true,
            type: 'primary',
        });
```

**Setup**

- [x] Pull down this PR.
- [x] Integrate into a project with a modal record action.

**Testing**

- [x] Update a model action record with both `type: 'primary' and `modal: true``.
- [x] View the model index and make sure the button is visible (not within a menu) and shows a modal.
