### PR TITLE
WIP: Added missing files to enable codecov upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ COPY /views /app/node_modules/linz/views
 COPY /linz.js /app/node_modules/linz/linz.js
 COPY /package.json /app/node_modules/linz/package.json
 
+COPY /codecov.yml /jest.config.js /app/
+
 COPY /app /app
 COPY /devops /app/devops
 COPY /test /app/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY /views /app/node_modules/linz/views
 COPY /linz.js /app/node_modules/linz/linz.js
 COPY /package.json /app/node_modules/linz/package.json
 
+# Enable codecov integration.
 COPY /codecov.yml /jest.config.js /app/
 
 COPY /app /app


### PR DESCRIPTION
Codecov integration broke at sometime in the past, which means the last build on `master` didn't report its coverage. Until this is fixed, no future PRs will show proper codecov output.

**Setup**

N/A

**Testing**

- [x] Review the updates in the PR.
- [x] Ensure the coverage report is uploaded to codecov (despite it still not being able to do a compare).

**Notes**

- I just want to quickly push this one into `master`.
