### PR TITLE
WIP: Export objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added the ability to split object fields over multiple columns in the default export.
+- Made the export api more generic so you can pass in any stream instead of a query.
 
 ## v1.0.0-18.1.0 (13 March 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added the ability to split object fields over multiple columns in the default export.
 - Made the export api more generic so you can pass in any stream instead of a query.
+- Fixed the transform function to pass the correct parameters.
 
 ## v1.0.0-18.1.0 (13 March 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Added the ability to split object fields over multiple columns in the default export.
+
 ## v1.0.0-18.1.0 (13 March 2019)
 
 - Made the modal selector more generic so it also works with custom modals.

--- a/app/models/mtUser.js
+++ b/app/models/mtUser.js
@@ -20,6 +20,7 @@ const mtUserSchema = new linz.mongoose.Schema({
     },
     password: String,
     username: String,
+    objectField: linz.mongoose.Schema.Types.Mixed,
 });
 
 // add the formtools plugin
@@ -74,6 +75,13 @@ mtUserSchema.plugin(linz.formtools.plugins.document, {
             fieldset: 'Access',
             helpText: 'This controls if the user has access to admin.',
         },
+        objectField: {
+            fieldset: 'Misc',
+            transpose: {
+                'export': (val) => Promise.resolve([val, true]),
+            },
+            visible: false,
+        },
     },
     labels: {
         bAdmin: 'Has admin access?',
@@ -96,9 +104,31 @@ mtUserSchema.plugin(linz.formtools.plugins.document, {
         ],
         export: [
             {
+                columns: (columns) => {
+
+                    // Usually you would want to filter out the object field based on the key
+                    // For testing purposes it has been left in.
+                    const updatedColumns = columns.slice();
+
+                    return updatedColumns.concat([
+                        {
+                            key: 'objectField1',
+                            header: 'Object Field 1',
+                        },
+                        {
+                            key: 'objectField2',
+                            header: 'Object Field 2',
+                        },
+                        {
+                            key: 'objectField3',
+                            header: 'Object Field 3',
+                        },
+                    ]);
+
+                },
+                dateFormat: 'DD MMM YYYY',
                 exclusions: '_id',
                 label: 'Choose fields to export',
-                dateFormat: 'DD MMM YYYY',
             },
         ],
     },

--- a/app/routes/reset-data.js
+++ b/app/routes/reset-data.js
@@ -18,6 +18,11 @@ module.exports = (req, res, next) => {
         bAdmin: true,
         email: 'test@test.com',
         name: 'Test user',
+        objectField: {
+            objectField1: 'Object Field 1',
+            objectField2: 'Object Field 2',
+            objectField3: 'Object Field 3',
+        },
         org: org._id,
         password: 'password',
         username: 'test',

--- a/docs/models_form.rst
+++ b/docs/models_form.rst
@@ -269,7 +269,7 @@ The ``query`` property can be used to directly alter the Mongoose query object t
 
 The ``transform`` property will accept a function with the signature::
 
-  transform (field, 'beforeSave', form, user)
+  transform (field, record)
 
 If provided, it will be executed before a record is saved to the database. It is useful if you need to manipulate client side data before it is stored in the database.
 

--- a/lib/api/formtools/parse-form.js
+++ b/lib/api/formtools/parse-form.js
@@ -67,12 +67,8 @@ const parseField = (fieldName, data, options = {}) => {
 
     const formItem = Object.assign({}, form[fieldName], form[fieldName][formType]);
 
-    if (formItem.widget && formItem.widget.transform) {
-        updatedField = formItem.widget.transform(fieldName, formItem, field, data);
-    }
-
     if (formItem.transform) {
-        updatedField = formItem.transform(field, 'beforeSave');
+        updatedField = formItem.transform(field, data);
     }
 
     return updatedField;

--- a/lib/api/util/file-export.js
+++ b/lib/api/util/file-export.js
@@ -4,15 +4,13 @@ const csvTransform = require('stream-transform');
 const csvStringify = require('csv-stringify');
 
 /**
- * Generate an export file from a query.
+ * Generate an export file from a stream.
  * Options can be found here https://csv.js.org
  * @param {Object} opts The options object.
  * @param {Array} opts.columns An array of key and header objects to use as the column header.
- * @param {Object} opts.query Mongoose query object.
- * @param {Object} opts.req HTTP request object.
+ * @param {Object} opts.stream A stream.
  * @param {Object} opts.res HTTP response object.
  * @param {String} [opts.extension='csv'] The name of the file extension.
- * @param {Function} opts.format Format function that takes the result of the query and returns the file string.
  * @param {String} opts.name The name of the file.
  * @param {Function} opts.transform A transform function to pass to the stream.
  * @return {Void} Send back a CSV file.
@@ -25,16 +23,12 @@ const generateExport = (opts) => {
         transform: (doc) => doc,
     }, opts);
 
-    if (!options.req) {
-        throw new Error('req is a required property');
-    }
-
     if (!options.res) {
         throw new Error('res is a required property');
     }
 
-    if (!options.query) {
-        throw new Error('query is a required property');
+    if (!options.stream) {
+        throw new Error('stream is a required property');
     }
 
     options.res.setHeader('Content-disposition', `attachment; filename=${options.name}.${options.extension}`);
@@ -43,9 +37,7 @@ const generateExport = (opts) => {
         options.res.setHeader('Content-Type', options.contentType);
     }
 
-    options.query.lean()
-        .cursor()
-        .pipe(csvTransform(options.transform))
+    options.stream.pipe(csvTransform(options.transform))
         .pipe(csvStringify({
             columns: options.columns,
             header: true,

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -355,6 +355,7 @@ var exportDefault = function (exports) {
 
         var expObj = {
             action: exp.action || 'export',
+            columns: exp.columns,
             dateFormat: exp.dateFormat || false,
             enabled: !(exp.enable === true),
             exclusions: exp.exclusions || '_id,dateCreated,dateModified,createdBy,modifiedBy',

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -383,9 +383,8 @@ module.exports = {
                     }))),
                     contentType: 'text/csv',
                     name: `${Model.linz.formtools.model.plural}-${moment(Date.now()).format('l').replace(/\//g, '.', 'g')}`,
-                    query: exportQuery,
-                    req,
                     res,
+                    stream: exportQuery.lean().cursor(),
                     transform: (doc, callback) => {
 
                         const fields = Object.keys(doc);

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -374,12 +374,13 @@ module.exports = {
                 }
 
                 const exportQuery = query.select(filterFieldNames.join(' '));
+                const columnsFn = exportObj.columns || ((columns) => columns);
 
                 linz.api.util.generateExport({
-                    columns: fields.map((fieldName) => ({
+                    columns: columnsFn(fields.map((fieldName) => ({
                         key: fieldName,
                         header: labels[fieldName],
-                    })),
+                    }))),
                     contentType: 'text/csv',
                     name: `${Model.linz.formtools.model.plural}-${moment(Date.now()).format('l').replace(/\//g, '.', 'g')}`,
                     query: exportQuery,
@@ -395,7 +396,23 @@ module.exports = {
                             if (getTransposeFn(form, fieldName, 'export')) {
 
                                 return promises.push(getTransposeFn(form, fieldName, 'export')(doc[fieldName], doc)
-                                    .then((val) => (doc[fieldName] = val)));
+                                    .then((result) => {
+
+                                        const updatedDoc = doc;
+                                        let val = result;
+                                        let merge = false;
+
+                                        if (Array.isArray(val)) {
+                                            [val, merge = false] = val;
+                                        }
+
+                                        if (!merge) {
+                                            return (doc[fieldName] = val);
+                                        }
+
+                                        return (doc = Object.assign({}, updatedDoc, val));
+
+                                    }));
 
                             }
 


### PR DESCRIPTION
## This has been superseded by https://github.com/linzjs/linz/pull/254 Please merge that instead.

This PR adds the ability to split an object field into multiple columns in an export.

**Setup**

- [ ] Re import the default data using the route `/reset`.

**Related PRs**

- https://github.com/linzjs/linz/pull/109

**Testing**

- [ ] Export the `Object field` field on the user model.
- [ ] Make sure you can see the `Object field` and 3 other `Object field X` fields which are the properties of the objectField.
- [ ] Update L81 of `app/models/mtUser.js` 
to be false `'export': (val) => Promise.resolve([val, false]),` and create another export.
- [ ] You should not see any of the property fields `Object field X`.
- [ ] Update L81 of `app/models/mtUser.js` 
to be false `'export': (val) => Promise.resolve(val),` and create another export.
- [ ] You should not see any of the property fields `Object field X`.

**Notes**

- Usually you would filter out the column header for the merge field, but I have left it in there to show the difference between the original and merged fields.
