### PR TITLE
improve error alerts in versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v1.0.0-18.2.0 (12 April 2019)
+
+- Linz's error handling middleware will now add the error to `req`.
+- Linz's error handling middleware can now return errors via JSON.
+- Updated error handling for JSON errors.
+- Added `linz.api.error` functions.
+- Added routes to the example app to generate errors for testing purposes.
+- Updated documentation.
+
 ## v1.0.0-18.1.0 (13 March 2019)
 
 - Made the modal selector more generic so it also works with custom modals.

--- a/app/app.js
+++ b/app/app.js
@@ -1,15 +1,17 @@
 'use strict';
 
 const { EventEmitter } = require('events');
+const editCustomRoute = require('./routes/edit-custom');
+const error = require('./routes/error');
+const errorJson = require('./routes/error-json');
 const express = require('express');
+const handlebars = require('express-handlebars');
 const http = require('http');
 const linz = require('linz');
-const session = require('./lib/session');
-const scripts = require('./lib/scripts');
-const styles = require('./lib/styles');
-const editCustomRoute = require('./routes/edit-custom');
 const resetData = require('./routes/reset-data');
-const handlebars = require('express-handlebars');
+const scripts = require('./lib/scripts');
+const session = require('./lib/session');
+const styles = require('./lib/styles');
 
 const port = 8888;
 
@@ -46,6 +48,9 @@ class App extends EventEmitter {
 
             linz.app.get('/', (req, res) => res.redirect(linz.get('login path')));
             linz.app.get('/reset', resetData);
+            linz.app.get('/error', error);
+            linz.app.get('/error-json', errorJson);
+
             // Custom form example.
             linz.app.get(`${linz.get('admin path')}/model/mtUser/:id/action/edit-custom`, editCustomRoute.get);
             linz.app.post(`${linz.get('admin path')}/model/mtUser/:id/action/edit-custom`, editCustomRoute.post);

--- a/app/routes/error-json.js
+++ b/app/routes/error-json.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const linz = require('linz');
+
+module.exports = (req, res, next) => {
+
+    return next(linz.api.error.json(new Error('Simulated error')));
+
+};

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = (req, res, next) => {
+
+    return next(new Error('Simulated error'));
+
+};

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,19 @@ At present, we're working on a long term effort to expose all of Linz's function
 
 You can access the Linz APIs via ``linz.api``.
 
+error
+=====
+
+error.json(err, statusCode = 500)
+---------------------------------
+
+Take an Error object and add ``err`` and ``statusCode`` properties. In an error is encountered by the Linz error handling middleware with these properties, the error will be return via JSON, rather than HTML.
+
+error.store(err, req)
+---------------------
+
+Take an Error object and store it on ``req`` within the Linz namespace at ``req.linz.error``. This becomes useful for logging errors that might be produced by Linz.
+
 model
 =====
 

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -1,0 +1,42 @@
+.. highlight:: javascript
+
+**************
+Error handling
+**************
+
+Linz consistently manages all errors by passing the error through to `next`. This allows a consistent approach to error handleing and provides a centralised approach to intercept those errors if desired.
+
+Linz provides an error handling middleware at ``linz.api.middleware.error``. You should mount this to your Express app as the last piece of error middleware. It will:
+
+- Log ``err.stack`` to ``console.error``.
+- Store the error at ``req.linz.error``.
+- Return the error in the context of JSON, or display the error in a view.
+
+Recording errors
+----------------
+
+You can use some middleware to trap all errors that happen within Linz. For example::
+
+    module.exports = (req, res, next) => {
+
+        res.on('finish', () => {
+
+            if (req.complete && req.linz && req.linz.error) {
+                console.error(req.linz.error);
+            }
+
+        });
+
+        return next();
+
+    };
+
+JSON errors
+-----------
+
+If an error occurs within Linz, in the context of a JSON request, Linz will decorate the error with two properties:
+
+- `json` will be `true`.
+- `statusCode` will be `500`.
+
+If the Linz error handling middleware captures an error with those properties, will return the error via JSON.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Linz is quite new and under rapid development. It is used quite successfully in 
 
    notifications
    request_namespace
+   error_handling
 
 .. _advanced-docs:
 

--- a/lib/api/error.js
+++ b/lib/api/error.js
@@ -6,7 +6,7 @@
  * @param  {Number} statusCode The statusCode to return.
  * @return {Error}             The decorate error object.
  */
-function json (err, statusCode = 500) {
+const json = (err, statusCode = 500) => {
 
     err.json = true;
     err.statusCode = statusCode;
@@ -21,14 +21,16 @@ function json (err, statusCode = 500) {
  * @param  {Error} err  The error that occurred.
  * @return {Void}
  */
-function store (err, req) {
+const store = (err, req) => {
 
     req.linz = req.linz || {};
     req.linz.error = err;
 
+    return req;
+
 }
 
 module.exports = {
-    json: json,
-    store: store,
+    json,
+    store,
 };

--- a/lib/api/error.js
+++ b/lib/api/error.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Set a flag to denote this error should be returned via JSON.
+ * @param  {Error} err         The error to decorate.
+ * @param  {Number} statusCode The statusCode to return.
+ * @return {Error}             The decorate error object.
+ */
+function json (err, statusCode = 500) {
+
+    err.json = true;
+    err.statusCode = statusCode;
+
+    return err;
+
+}
+
+/**
+ * Store an error that has occurred on req.
+ * @param  {Object} req A HTTP request object.
+ * @param  {Error} err  The error that occurred.
+ * @return {Void}
+ */
+function store (err, req) {
+
+    req.linz = req.linz || {};
+    req.linz.error = err;
+
+}
+
+module.exports = {
+    json: json,
+    store: store,
+};

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -2,6 +2,7 @@
 
 module.exports.configs = require('./configs');
 module.exports.date = require('./date');
+module.exports.error = require('./error');
 module.exports.formtools = require('./formtools');
 module.exports.middleware = require('./middleware');
 module.exports.model = require('./model');

--- a/lib/api/middleware/error.js
+++ b/lib/api/middleware/error.js
@@ -4,11 +4,17 @@ const linz = require('../../../');
 
 module.exports = function (err, req, res, next) {
 
+    linz.api.error.store(err, req);
+
     if (err.code === 'EBADCSRFTOKEN') {
         err.message = (!req.body._csrf || req.body._csrf === 'undefined') ? 'No CSRF token was provided.' : 'The wrong CSRF token was provided.';
     }
 
     console.error(err.stack);
+
+    if (err.json) {
+        return res.status(err.statusCode || 500).json({ error: err.message });
+    }
 
     Promise.all([
         linz.api.views.getScripts(req, res),

--- a/middleware/recordChange.js
+++ b/middleware/recordChange.js
@@ -210,7 +210,7 @@ module.exports = function (req, res, next) {
     ], function (err, result) {
 
         if (err) {
-            return res.status(500).json({ error: err.message });
+            return next(linz.api.error.json(err));
         }
 
         if (!result) {
@@ -270,7 +270,7 @@ module.exports = function (req, res, next) {
                 return res.status(200).json(resData);
 
             })
-            .catch((error) => res.status(500).json({ error: error.message }));
+            .catch((err) => next(linz.api.error.json(err)));
 
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-18.1.0",
+  "version": "1.0.0-18.2.0",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",

--- a/public/js/model/check-record-changes.js
+++ b/public/js/model/check-record-changes.js
@@ -71,9 +71,10 @@ if (!linz) {
         .fail(function(res) {
 
             var json = res.responseJSON;
-            var errorMessage = json.error;
 
             if (json) {
+
+                var errorMessage = json.error;
 
                 console.error(errorMessage);
 

--- a/public/js/model/check-record-changes.js
+++ b/public/js/model/check-record-changes.js
@@ -68,9 +68,21 @@ if (!linz) {
             });
 
         })
-        .fail(function(jqXHR, textStatus, errorThrown ) {
+        .fail(function(res) {
 
-            alert('An error has occured while attempting to check if this record has been editted by other user.');
+            var json = res.responseJSON;
+            var errorMessage = json.error;
+
+            if (json) {
+
+                console.error(errorMessage);
+
+                return alert(errorMessage);
+
+            }
+
+            alert('An error has occurred while attempting to check if this record has been edited by another user.');
+
             return false;
 
         });

--- a/public/js/model/check-record-changes.js
+++ b/public/js/model/check-record-changes.js
@@ -74,7 +74,7 @@ if (!linz) {
 
             if (json) {
 
-                return alert(json.error);
+                return alert('An error has occurred: ' + json.error);
 
             }
 

--- a/public/js/model/check-record-changes.js
+++ b/public/js/model/check-record-changes.js
@@ -74,11 +74,7 @@ if (!linz) {
 
             if (json) {
 
-                var errorMessage = json.error;
-
-                console.error(errorMessage);
-
-                return alert(errorMessage);
+                return alert(json.error);
 
             }
 

--- a/test/api-error.test.js
+++ b/test/api-error.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { json, store } = require('linz/lib/api/error');
+
+test('stores the error on req', () => {
+
+    const err = new Error('Test error');
+    const req = {};
+
+    store(err, req);
+
+    expect(req.linz).toBeTruthy();
+    expect(req.linz.error.message).toBe(err.message);
+
+});
+
+test('sets json and statusCode properties on an error', () => {
+
+    const err = new Error('Test error');
+
+    json(err);
+
+    expect(err.json).toBeDefined();
+    expect(err.json).toBeTruthy();
+
+    expect(err.statusCode).toBeDefined();
+    expect(err.statusCode).toBe(500);
+
+});

--- a/test/api-middleware-error.test.js
+++ b/test/api-middleware-error.test.js
@@ -1,29 +1,89 @@
 'use strict';
 
-const { json, store } = require('linz/lib/api/error');
+const middleware = require('../lib/api/middleware/error');
+const { json } = require('../lib/api/error');
+const consoleError = console.error;
+
+beforeAll(() => (console.error = jest.fn()));
+afterAll(() => (console.error = consoleError));
 
 test('stores the error on req', () => {
 
     const err = new Error('Test error');
     const req = {};
+    const res = {};
+    const next = jest.fn();
 
-    store(err, req);
+    middleware(err, req, res, next);
 
     expect(req.linz).toBeTruthy();
     expect(req.linz.error.message).toBe(err.message);
+    expect(next.mock.calls.length).toBe(0);
 
 });
 
-test('sets json and statusCode properties on an error', () => {
+test('CSRF error message is updated', () => {
 
-    const err = new Error('Test error');
+    const err = new Error('invalid csrf token');
+    const req = { body: {} };
+    const res = {};
+    const next = jest.fn();
 
-    json(err);
+    err.code = 'EBADCSRFTOKEN';
 
-    expect(err.json).toBeDefined();
-    expect(err.json).toBeTruthy();
+    middleware(err, req, res, next);
 
-    expect(err.statusCode).toBeDefined();
-    expect(err.statusCode).toBe(500);
+    expect(req.linz).toBeTruthy();
+    expect(req.linz.error.code).toBe('EBADCSRFTOKEN');
+    expect(req.linz.error.message).toBe('No CSRF token was provided.');
+    expect(next.mock.calls.length).toBe(0);
+
+    req.body._csrf = 'ASDF';
+
+    middleware(err, req, res, next);
+
+    expect(req.linz).toBeTruthy();
+    expect(req.linz.error.code).toBe('EBADCSRFTOKEN');
+    expect(req.linz.error.message).toBe('The wrong CSRF token was provided.');
+    expect(next.mock.calls.length).toBe(0);
+
+});
+
+test('Returns the error via json', () => {
+
+    const err = json(new Error('JSON error test'));
+    const req = {};
+    const res = { status: jest.fn(() => res), json: jest.fn(() => res) };
+    const next = jest.fn();
+
+    middleware(err, req, res, next);
+
+    expect(res.status).toBeCalled();
+    expect(res.status.mock.calls.length).toBe(1);
+    expect(res.status).toBeCalledWith(500);
+
+    expect(res.json).toBeCalled();
+    expect(res.json.mock.calls.length).toBe(1);
+    expect(res.json).toBeCalledWith({ error: err.message });
+
+    expect(next.mock.calls.length).toBe(0);
+
+});
+
+test('The error is logged to console', () => {
+
+    const err = new Error('JSON error test');
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    console.error = jest.fn();
+
+    middleware(err, req, res, next);
+
+    expect(console.error).toBeCalled();
+    expect(console.error.mock.calls.length).toBe(1);
+
+    expect(next.mock.calls.length).toBe(0);
 
 });

--- a/test/api-middleware-error.test.js
+++ b/test/api-middleware-error.test.js
@@ -1,19 +1,29 @@
 'use strict';
 
-const error = require('linz/lib/api/middleware/error');
+const { json, store } = require('linz/lib/api/error');
 
 test('stores the error on req', () => {
 
     const err = new Error('Test error');
     const req = {};
-    const res = {
-        status: jest.fn(code => res),
-        send: jest.fn(),
-    };
 
-    error(err, req, res);
+    store(err, req);
 
     expect(req.linz).toBeTruthy();
     expect(req.linz.error.message).toBe(err.message);
+
+});
+
+test('sets json and statusCode properties on an error', () => {
+
+    const err = new Error('Test error');
+
+    json(err);
+
+    expect(err.json).toBeDefined();
+    expect(err.json).toBeTruthy();
+
+    expect(err.statusCode).toBeDefined();
+    expect(err.statusCode).toBe(500);
 
 });

--- a/test/api-middleware-error.test.js
+++ b/test/api-middleware-error.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const error = require('linz/lib/api/middleware/error');
+
+test('stores the error on req', () => {
+
+    const err = new Error('Test error');
+    const req = {};
+    const res = {
+        status: jest.fn(code => res),
+        send: jest.fn(),
+    };
+
+    error(err, req, res);
+
+    expect(req.linz).toBeTruthy();
+    expect(req.linz.error.message).toBe(err.message);
+
+});


### PR DESCRIPTION
This PR improves the readability of error alerts in the versions plugin.

**Setup**

- [x] Add this to a project.

**Testing**

- [x] Generate an error (not a csrf one) an make sure the alert is different from the generic one.