### PR TITLE
navigation cache id

### DIFF
--- a/lib/api/navigation.js
+++ b/lib/api/navigation.js
@@ -5,8 +5,10 @@ var linz = require('../../'),
 
 function get (req, cb) {
 
-    if (!linz.get('disable navigation cache') && !req.linz.cache.navigation.invalidate && req.session.navigation) {
-        return cb(null, req.session.navigation);
+    var validNavigationCache = req.session.navigation && linz.get('navigation cache id') === req.session.navigationCacheId;
+
+    if (!linz.get('disable navigation cache') && !req.linz.cache.navigation.invalidate && validNavigationCache) {
+        return cb(null, navigation);
     }
 
     debugCache('Priming navigation cache');
@@ -100,6 +102,8 @@ function get (req, cb) {
                     nestedNavigation = navigation;
 
                     req.session.navigation = navigation;
+
+                    req.session.navigationCacheId = linz.get('navigation cache id');
 
                     return callback(null, nestedNavigation);
 

--- a/lib/api/navigation.js
+++ b/lib/api/navigation.js
@@ -8,7 +8,7 @@ function get (req, cb) {
     var validNavigationCache = req.session.navigation && linz.get('navigation cache id') === req.session.navigationCacheId;
 
     if (!linz.get('disable navigation cache') && !req.linz.cache.navigation.invalidate && validNavigationCache) {
-        return cb(null, navigation);
+        return cb(null, req.session.navigation);
     }
 
     debugCache('Priming navigation cache');

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -63,6 +63,7 @@ module.exports = {
 
     // cache
     'disable navigation cache': false,
+    'navigation cache id': '0',
 
     'navigationTransform': nav => nav,
 


### PR DESCRIPTION
This PR add an ID to differentiate navigation item cache

**Testing**

- [ ] Build and run the app,
- [ ] Add `'navigation cache id' : '1',` to `options` in `linz.init()`.
- [ ] Create a new model
- [ ] Build and run the app, visit `/admin/models/list`
- [ ] The model created should be available in the navigation menu


