### PR TITLE
Export fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+- Added the ability to split object fields over multiple columns in the default export.
+- Made the export api more generic so you can pass in any stream instead of a query.
+- Fixed the transform function to pass the correct parameters.
+
 ## v1.0.0-18.3.1 (18 April 2019)
 
 - Fixed concurrency plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v1.0.0-18.4.0 (27 May 2019)
 
 - Added the ability to split object fields over multiple columns in the default export.
 - Made the export api more generic so you can pass in any stream instead of a query.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added the ability to split object fields over multiple columns in the default export.
 - Made the export api more generic so you can pass in any stream instead of a query.
 - Fixed the transform function to pass the correct parameters.
+- Fixed listQuery not being applied in the exports.
+- Fixed single field and record exports not showing up correctly.
 
 ## v1.0.0-18.3.1 (18 April 2019)
 

--- a/app/models/mtOrg.js
+++ b/app/models/mtOrg.js
@@ -26,7 +26,7 @@ mtOrgSchema.plugin(linz.formtools.plugins.document, {
 
 mtOrgSchema.pre('save', function (next, callback, req) {
 
-    if (req.user) {
+    if (req && req.user) {
         this.modifiedBy = req.user.username;
     }
 

--- a/app/models/mtUser/formtools/form.js
+++ b/app/models/mtUser/formtools/form.js
@@ -53,4 +53,11 @@ module.exports = {
         fieldset: 'Access',
         helpText: 'This controls if the user has access to admin.',
     },
+    objectField: {
+        fieldset: 'Misc',
+        transpose: {
+            'export': (val) => Promise.resolve([val, true]),
+        },
+        visible: false,
+    },
 };

--- a/app/models/mtUser/formtools/list.js
+++ b/app/models/mtUser/formtools/list.js
@@ -20,9 +20,31 @@ module.exports = {
     ],
     export: [
         {
+            columns: (columns) => {
+
+                // Usually you would want to filter out the object field based on the key
+               // For testing purposes it has been left in.
+               const updatedColumns = columns.slice();
+
+                return updatedColumns.concat([
+                   {
+                       key: 'objectField1',
+                       header: 'Object Field 1',
+                   },
+                   {
+                       key: 'objectField2',
+                       header: 'Object Field 2',
+                   },
+                   {
+                       key: 'objectField3',
+                       header: 'Object Field 3',
+                   },
+               ]);
+
+            },
+            dateFormat: 'DD MMM YYYY',
             exclusions: '_id',
             label: 'Choose fields to export',
-            dateFormat: 'DD MMM YYYY',
         },
     ],
 };

--- a/app/models/mtUser/index.js
+++ b/app/models/mtUser/index.js
@@ -18,7 +18,7 @@ mtUserSchema.methods.verifyPassword = function (candidatePassword, callback) {
 
 mtUserSchema.pre('save', function (next, callback, req) {
 
-    if (req.user) {
+    if (req && req.user) {
         this.modifiedBy = req.user.username;
     }
 

--- a/app/models/mtUser/schema.js
+++ b/app/models/mtUser/schema.js
@@ -21,6 +21,7 @@ const mtUserSchema = new linz.mongoose.Schema({
     },
     password: String,
     username: String,
+    objectField: linz.mongoose.Schema.Types.Mixed,
 });
 
 module.exports = mtUserSchema;

--- a/app/routes/reset-data.js
+++ b/app/routes/reset-data.js
@@ -24,6 +24,11 @@ module.exports = (req, res, next) => {
         email: 'test@test.com',
         modifiedBy: 'reset-script',
         name: 'Test user',
+        objectField: {
+            objectField1: 'Object Field 1',
+            objectField2: 'Object Field 2',
+            objectField3: 'Object Field 3',
+        },
         org: org._id,
         password: 'password',
         username: 'test',

--- a/docs/models_form.rst
+++ b/docs/models_form.rst
@@ -269,7 +269,7 @@ The ``query`` property can be used to directly alter the Mongoose query object t
 
 The ``transform`` property will accept a function with the signature::
 
-  transform (field, 'beforeSave', form, user)
+  transform (field, record)
 
 If provided, it will be executed before a record is saved to the database. It is useful if you need to manipulate client side data before it is stored in the database.
 

--- a/lib/api/formtools/parse-form.js
+++ b/lib/api/formtools/parse-form.js
@@ -67,12 +67,8 @@ const parseField = (fieldName, data, options = {}) => {
 
     const formItem = Object.assign({}, form[fieldName], form[fieldName][formType]);
 
-    if (formItem.widget && formItem.widget.transform) {
-        updatedField = formItem.widget.transform(fieldName, formItem, field, data);
-    }
-
     if (formItem.transform) {
-        updatedField = formItem.transform(field, 'beforeSave');
+        updatedField = formItem.transform(field, data);
     }
 
     return updatedField;

--- a/lib/api/util/file-export.js
+++ b/lib/api/util/file-export.js
@@ -41,6 +41,7 @@ const generateExport = (opts) => {
         .pipe(csvStringify({
             columns: options.columns,
             header: true,
+            quoted: true,
         }))
         .pipe(options.res);
 

--- a/lib/api/util/file-export.js
+++ b/lib/api/util/file-export.js
@@ -4,15 +4,13 @@ const csvTransform = require('stream-transform');
 const csvStringify = require('csv-stringify');
 
 /**
- * Generate an export file from a query.
+ * Generate an export file from a stream.
  * Options can be found here https://csv.js.org
  * @param {Object} opts The options object.
  * @param {Array} opts.columns An array of key and header objects to use as the column header.
- * @param {Object} opts.query Mongoose query object.
- * @param {Object} opts.req HTTP request object.
+ * @param {Object} opts.stream A stream.
  * @param {Object} opts.res HTTP response object.
  * @param {String} [opts.extension='csv'] The name of the file extension.
- * @param {Function} opts.format Format function that takes the result of the query and returns the file string.
  * @param {String} opts.name The name of the file.
  * @param {Function} opts.transform A transform function to pass to the stream.
  * @return {Void} Send back a CSV file.
@@ -25,16 +23,12 @@ const generateExport = (opts) => {
         transform: (doc) => doc,
     }, opts);
 
-    if (!options.req) {
-        throw new Error('req is a required property');
-    }
-
     if (!options.res) {
         throw new Error('res is a required property');
     }
 
-    if (!options.query) {
-        throw new Error('query is a required property');
+    if (!options.stream) {
+        throw new Error('stream is a required property');
     }
 
     options.res.setHeader('Content-disposition', `attachment; filename=${options.name}.${options.extension}`);
@@ -43,9 +37,7 @@ const generateExport = (opts) => {
         options.res.setHeader('Content-Type', options.contentType);
     }
 
-    options.query.lean()
-        .cursor()
-        .pipe(csvTransform(options.transform))
+    options.stream.pipe(csvTransform(options.transform))
         .pipe(csvStringify({
             columns: options.columns,
             header: true,

--- a/lib/formtools/plugins/document.js
+++ b/lib/formtools/plugins/document.js
@@ -242,4 +242,6 @@ module.exports = function formtoolsPlugin (schema, options) {
 
     }
 
+    schema.statics.listQuery = (req, query, cb) => cb(null, query);
+
 };

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -355,6 +355,7 @@ var exportDefault = function (exports) {
 
         var expObj = {
             action: exp.action || 'export',
+            columns: exp.columns,
             dateFormat: exp.dateFormat || false,
             enabled: !(exp.enable === true),
             exclusions: exp.exclusions || '_id,dateCreated,dateModified,createdBy,modifiedBy',

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -380,17 +380,18 @@ module.exports = {
                     }
 
                     const exportQuery = listQuery.select(filterFieldNames.join(' '));
+                    const columnsFn = exportObj.columns || ((columns) => columns);
 
                     linz.api.util.generateExport({
-                        columns: fields.map((fieldName) => ({
+                        columns: columnsFn(fields.map((fieldName) => ({
                             key: fieldName,
                             header: labels[fieldName],
-                        })),
+                        }))),
                         contentType: 'text/csv',
                         name: `${Model.linz.formtools.model.plural}-${moment(Date.now()).format('l').replace(/\//g, '.', 'g')}`,
-                        query: exportQuery,
                         req,
                         res,
+                        stream: exportQuery.lean().cursor(),
                         transform: (doc, callback) => {
 
                             const fields = Object.keys(doc);
@@ -401,7 +402,23 @@ module.exports = {
                                 if (getTransposeFn(form, fieldName, 'export')) {
 
                                     return promises.push(getTransposeFn(form, fieldName, 'export')(doc[fieldName], doc)
-                                        .then((val) => (doc[fieldName] = val)));
+                                        .then((result) => {
+
+                                            const updatedDoc = doc;
+                                            let val = result;
+                                            let merge = false;
+
+                                            if (Array.isArray(val)) {
+                                                [val, merge = false] = val;
+                                            }
+
+                                            if (!merge) {
+                                                return (doc[fieldName] = val);
+                                            }
+
+                                            return (doc = Object.assign({}, updatedDoc, val));
+
+                                        }));
 
                                 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-18.3.1",
+  "version": "1.0.0-18.4.0",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",


### PR DESCRIPTION
This PR fixes:
- Exports to use the listQuery if provided.
- CSV issue when there is only 1 export field and it contains spaces.
- Adds the ability to split an object field into multiple columns in an export.

**Related PRs**

- #238
- #241 

**Testing**

- [x] Using the test app, reset the data `http://localhost:8888/reset`.
- [x] Export the `Object field` field on the user model.
- [x] Make sure you can see the `Object field` and 3 other `Object field X` fields which are the properties of the objectField.
- [x] Update L59 of `app/models/mtUser/formtools/form.js` 
to be false `'export': (val) => Promise.resolve([val, false]),` and create another export.
- [x] You should not see any of the property fields `Object field X`.
- [x] Update L59 of `app/models/mtUser/formtools/form.js` 
to be undefined `'export': (val) => Promise.resolve(val),` and create another export.
- [x] You should not see any of the property fields `Object field X`.

**Notes**

- Usually you would filter out the column header for the merge field, but I have left it in there to show the difference between the original and merged fields.
