### PR TITLE
Added modal support for exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased
+
+- Added support for `modal` form to custom exports.
+
 ## v1.0.0-18.4.0 (27 May 2019)
 
 - Added the ability to split object fields over multiple columns in the default export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG
 
-## unreleased
+## 1.0.0-18.4.2 (31 May 2019)
 
 - Added support for `modal` form to custom exports.
 
-## v1.0.0-18.4.1
+## v1.0.0-18.4.1 (29 May 2019)
 
 - Stopped empty date fields getting today's date automatically applied.
 

--- a/docs/models_list.rst
+++ b/docs/models_list.rst
@@ -66,6 +66,7 @@ When a user clicks on an export, they'll be provided a pop-up modal asking them 
       exclusions: 'dateModified,dateCreated',
       dateFormat: linz.get('date format'),
       useLocalTime: false,
+      modal: false,
     }
   ]
 
@@ -75,6 +76,7 @@ Each object should contain the following keys:
 - ``exclusions`` which is a list of fields that can't be exported.
 - ``dateFormat`` which allows you to format the exported dates using moment date formats. (Defaults to false)
 - ``useLocalTime`` which allows you to export date fields in the browsers timezone offset.
+- ``modal`` optionally render the results in a modal view.
 
 If you'd like to provide your own export route, you can. Replace the ``exclusions`` key with an ``action`` key that works the same as `list.actions`_. Rather than a modal, a request to that route will be made. You're responsible for mounting a ``GET`` route in Express to respond to it.
 

--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -359,6 +359,7 @@ var exportDefault = function (exports) {
             enabled: !(exp.enable === true),
             exclusions: exp.exclusions || '_id,dateCreated,dateModified,createdBy,modifiedBy',
             label: exp.label,
+            modal: exp.modal || false,
             permission: exp.permission || undefined,
             useLocalTime: exp.useLocalTime || false,
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-18.4.1",
+  "version": "1.0.0-18.4.2",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",

--- a/views/modelIndex/header.jade
+++ b/views/modelIndex/header.jade
@@ -59,7 +59,7 @@
 				for exp in model.list.export
 					if exp.enabled && permissions.canExport !== false
 						- attributes = {}
-						if exp.action === 'export'
+						if exp.action === 'export' || exp.modal
 							- attributes['data-target'] = '#exportModal'
 						a.btn.btn-default(href='' + linz.api.url.getAdminLink(model, exp.action) data-linz-control="export" class=(exp.action && 'disabled'))&attributes(attributes)= exp.label
 			else

--- a/views/modelIndex/header.jade
+++ b/views/modelIndex/header.jade
@@ -71,7 +71,7 @@
 						for exp in model.list.export
 							if exp.enabled && permissions.canExport !== false
 								- attributes = {}
-								if exp.action === 'export'
+								if exp.action === 'export' || exp.modal
 									- attributes['data-target'] = '#exportModal'
 								li(role='presentation')
 									a(role='menuitem' tabindex='-1' href='' + linz.api.url.getAdminLink(model, exp.action) data-linz-control='export')&attributes(attributes)= exp.label


### PR DESCRIPTION
This PR enables custom exports display modal

**Setup**

- [x] add the following to `export` object in `models/mtUser/formtools/list.js`
```
{
            label: 'Modal',
            modal: true,
            action: 'export/',
        },
        {
            label: 'Normal',
            action: 'some/route',
        },
```
- [x] `yarn start`

**Testing**

- [x] visit http://localhost:8888/admin/model/mtUser/list
- [x] click `Export` dropdown
- [x] click `Modal`, should display a modal (default export in this case)
- [x] click `Normal`, should make a post request to `/admin/model/mtUser/some/route`
