### PR TITLE
Stop default dates being applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v1.0.0-18.4.1
 
 - Stopped empty date fields getting today's date automatically applied.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Stopped empty date fields getting today's date automatically applied.
+
 ## v1.0.0-18.4.0 (27 May 2019)
 
 - Added the ability to split object fields over multiple columns in the default export.

--- a/lib/api/formtools/parse-form.js
+++ b/lib/api/formtools/parse-form.js
@@ -44,14 +44,7 @@ const parseField = (fieldName, data, options = {}) => {
     }
 
     if (type === 'date') {
-
-        // Don't assign the date unless it's valid
-        const d = new Date(field);
-
-        if (d instanceof Date && !isNaN(d)) {
-            updatedField = d;
-        }
-
+        updatedField = new Date(field);
     }
 
     if (type === 'number') {
@@ -73,6 +66,10 @@ const parseField = (fieldName, data, options = {}) => {
     }
 
     const formItem = Object.assign({}, form[fieldName], form[fieldName][formType]);
+
+    if (formItem.widget && formItem.widget.transform) {
+        updatedField = formItem.widget.transform(fieldName, formItem, field, data);
+    }
 
     if (formItem.transform) {
         updatedField = formItem.transform(field, data);

--- a/lib/api/formtools/parse-form.js
+++ b/lib/api/formtools/parse-form.js
@@ -44,7 +44,14 @@ const parseField = (fieldName, data, options = {}) => {
     }
 
     if (type === 'date') {
-        updatedField = new Date(field);
+
+        // Don't assign the date unless it's valid
+        const d = new Date(field);
+
+        if (d instanceof Date && !isNaN(d)) {
+            updatedField = d;
+        }
+
     }
 
     if (type === 'number') {

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -71,7 +71,7 @@ const setTemplateScripts = (req, res, templateScripts) => new Promise((resolve, 
             src: `${linz.get('admin path')}/public/js/template.js`,
         },
         {
-            src: `${linz.get('admin path')}/public/js/ui.js?v4`,
+            src: `${linz.get('admin path')}/public/js/ui.js?v5`,
         },
         {
             src: `${linz.get('admin path')}/public/js/validator.min.js?v1`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-18.4.0",
+  "version": "1.0.0-18.4.1",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -260,7 +260,7 @@ if (!linz) {
                 var field = $(this);
                 var dateValue = field.attr('data-linz-date-value');
 
-                // Don't default the default, only continue if there is one already.
+                // Don't default the date, only continue if there is one already.
                 if (!dateValue) {
                     return;
                 }

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -260,6 +260,11 @@ if (!linz) {
                 var field = $(this);
                 var dateValue = field.attr('data-linz-date-value');
 
+                // Don't default the default, only continue if there is one already.
+                if (!dateValue) {
+                    return;
+                }
+
                 if (field.data('utc-offset')) {
                     return field.data('DateTimePicker').date(moment(dateValue).subtract(getOffset(moment().format('Z')) - getOffset(field.data('utc-offset')), 'minutes'));
                 }


### PR DESCRIPTION
At the moment, if an empty date field appears on a model create/edit field, today's date is applied and this information can erroneously be saved against the record.

## Verification and testing

- [x] Before pulling down this branch (start on `master`), execute `yarn start`.
- [x] Visit http://localhost:8888/ and log in.
- [x] Navigate to Users.
- [x] Edit the `test` user.
- [x] The _Birthday_ and _Custom offset_ fields should be default to today's date (incorrectly).
- [x] Hit save.
- [x] View the `/json` route for that record and confirm the `birthday` and `customOffset` fields have been saved.
- [x] Pull down this branch and restart Linz with `yarn start`.
- [x] Reset the data by visiting http://localhost:8888/reset.
- [x] Navigate to Users.
- [x] Edit the `test` user.
- [x] The _Birthday_ and _Custom offset_ fields should not be set.
- [x] Hit save.
- [x] View the `/json` route for that record and confirm the `birthday` and `customOffset` fields have `null` values.
- [x] Edit the `test` user.
- [x] Set the _Birthday_ field.
- [x] Hit save.
- [x] View the `/json` route for that record and confirm the `birthday` has a date and `customOffset` has a `null` value.
