### PR TITLE
Group action fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Fixed group actions on the list view.
+
 ## 1.0.0-18.4.2 (31 May 2019)
 
 - Added support for `modal` form to custom exports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 1.0.0-18.4.3 (3 June 2019)
 
 - Fixed group actions on the list view.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-18.4.2",
+  "version": "1.0.0-18.4.3",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",

--- a/public/js/model/index.js
+++ b/public/js/model/index.js
@@ -230,7 +230,23 @@ linz.addLoadEvent(function () {
         var queryObj = $(this),
             url = queryObj.attr('href');
 
-        $('#groupActionModal').modal().load(url);
+        // Bind model save button and update the selected ids to modal form.
+        $('#groupActionModal').modal().load(url, function () {
+
+            var selectedIDs = [],
+                _this = this;
+
+            $('input[data-linz-control="checked-record"]:checked').each(function () {
+                selectedIDs.push($(this).val());
+            });
+
+            // add selected IDs to hidden field
+            $(_this).find('[data-group-action="ids"]').val(selectedIDs);
+
+            // add form validation
+            $(_this).find('form[data-linz-validation="true"]').bootstrapValidator({});
+
+        });
 
        return false;
     });
@@ -244,24 +260,6 @@ linz.addLoadEvent(function () {
         $('#recordActionModal').modal().load(url);
 
        return false;
-
-    });
-
-    // bind model save button and update the selected ids to modal form
-    $('#groupActionModal').on('shown.bs.modal', function (e) {
-
-        var selectedIDs = [],
-            _this = this;
-
-        $('input[data-linz-control="checked-record"]:checked').each(function () {
-            selectedIDs.push($(this).val());
-        });
-
-        // add selected IDs to hidden field
-        $(_this).find('[data-group-action="ids"]').val(selectedIDs);
-
-        // add form validation
-        $(_this).find('form[data-linz-validation="true"]').bootstrapValidator({});
 
     });
 

--- a/routes/modelIndex.js
+++ b/routes/modelIndex.js
@@ -15,7 +15,7 @@ var route = function (req, res, next) {
                 src: `${linz.get('admin path')}/public/js/template.polyfill.js`,
             },
             {
-                src: `${linz.get('admin path')}/public/js/model/index.js?v5`,
+                src: `${linz.get('admin path')}/public/js/model/index.js?v6`,
             },
         ]),
         linz.api.views.getStyles(req, res),

--- a/routes/recordOverview.js
+++ b/routes/recordOverview.js
@@ -19,7 +19,7 @@ var route = function (req, res, next) {
                 src: `${linz.get('admin path')}/public/js/template.polyfill.js`,
             },
             {
-                src: `${linz.get('admin path')}/public/js/model/index.js?v5`,
+                src: `${linz.get('admin path')}/public/js/model/index.js?v6`,
             },
         ]),
         linz.api.views.getStyles(req, res),


### PR DESCRIPTION
The `shown` event has been deprecated in bootstrap for remote modals. This PR provides a fix for that in the group actions.

**Setup**

- [ ] Verify the issue by trying to make some group action edits.

**Testing**

- [ ] Map in this PR and verify the group actions now work.
