### PR TITLE
fix the datepicker validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Fixed a bug preventing invalid date fields from being validated.
+
 ## 1.0.0-18.4.3 (3 June 2019)
 
 - Fixed group actions on the list view.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 1.0.0-18.4.4 (20 June 2019)
 
 - Fixed a bug preventing invalid date fields from being validated.
 

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -71,7 +71,7 @@ const setTemplateScripts = (req, res, templateScripts) => new Promise((resolve, 
             src: `${linz.get('admin path')}/public/js/template.js`,
         },
         {
-            src: `${linz.get('admin path')}/public/js/ui.js?v5`,
+            src: `${linz.get('admin path')}/public/js/ui.js?v6`,
         },
         {
             src: `${linz.get('admin path')}/public/js/validator.min.js?v1`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-18.4.3",
+  "version": "1.0.0-18.4.4",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -182,6 +182,15 @@ if (!linz) {
         e.preventDefault();
     }
 
+    // Trigger the necessary changes for the form validation
+    // https://github.com/nghuuphuoc/bootstrapvalidator/blob/0c96659eda586269c02a45948744ac135676ff0d/src/js/bootstrapValidator.js#L49
+    function triggerChange (field) {
+
+        field.trigger('keyup');
+        field.trigger('input');
+
+    }
+
     function loadDatepicker() {
 
         if ($('[data-ui-datepicker]').length) {
@@ -221,10 +230,10 @@ if (!linz) {
                 // Trigger the change event for the field whenever the datepicker is shown or changed.
                 field.on({
                     'dp.change': function() {
-                        field.change();
+                        triggerChange(field);
                     },
                     'dp.show': function () {
-                        field.change();
+                        triggerChange(field);
                     },
                 });
 


### PR DESCRIPTION
This PR fixes a bug with the datepicker validation.

**Setup**

- [x] Comment out https://github.com/linzjs/linz/blob/94c976af0cac7991f9628517b33590b61e8cfe25/app/models/mtUser/formtools/form.js#L35 and start the app on `master`.
- [x] Verify the issue by trying to create a new user without filling the form. An error should popup in the date field which you cannot get rid of.

**Testing**

- [x] Pull in this branch and repeat the verification steps. The error should now go away when you set a date.
