### PR TITLE
CSRF submit improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Improved client side CSRF code.
+
 ## 1.0.0-18.5.1 (4 July 2019)
 
 - Fixed a validation issue when a form has a remote validator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 1.0.0-18.5.2 (26 July 2019)
 
 - Improved client side CSRF code.
 

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -84,7 +84,7 @@ const setTemplateScripts = (req, res, templateScripts) => new Promise((resolve, 
         },
         {
             inHead: true,
-            src: `${linz.get('admin path')}/public/js/csrf-submit.js?v2`
+            src: `${linz.get('admin path')}/public/js/csrf-submit.js?v3`
         },
     ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linz",
-  "version": "1.0.0-18.5.1",
+  "version": "1.0.0-18.5.2",
   "description": "Node.js web application framework",
   "license": "MIT",
   "main": "linz.js",

--- a/public/js/csrf-submit.js
+++ b/public/js/csrf-submit.js
@@ -50,7 +50,7 @@ var mutated = function (mutationsList, observer) {
 
     mutationsList.forEach(function (mutation) {
 
-        if (mutation.type === 'childList' && mutation.addedNodes.length && !mutation.removedNodes.length) {
+        if (mutation.type === 'childList' && mutation.addedNodes.length) {
 
             for (var i = 0; i < mutation.addedNodes.length; i++) {
                 findAForm(mutation.addedNodes[i]);


### PR DESCRIPTION
This PR improvements the client side CSRF code.

## Testing and verification

- [x] Run Linz on `master`.
- [x] Navigate to Users.
- [x] Click the _Choose fields to export_ button, note the Export is not disabled.
- [x] Click the _Cancel_ button.
- [x] Click the _Choose fields to export_ button, note the Export button is disabled.
- [x] Pull down this PR.
- [x] Rebuild the Linz testing environment.
- [x] Run Linz on `master`.
- [x] Refresh the Users page.
- [x] Click the _Choose fields to export_ button, note the Export is not disabled.
- [x] Click the _Cancel_ button.
- [x] Click the _Choose fields to export_ button, note the Export is not disabled.
- [x] Click the _Cancel_ button.
- [x] Click the _Choose fields to export_ button, note the Export is not disabled.
- [x] Submit the export and make sure it works properly.

The problem should be solved :)