### PR TITLE
Ckeditor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed opening a documentArray with a datepicker resetting other date pickers on the main page to the current date.
 - Fixed multiple `linzTimezoneOffset` attributes.
 - Fixed incorrect datepicker dates across multiple timezones.
+- Fixed ckeditor double escaping values.
 
 ## v1.0.0-18.7.3 - 2019-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.0-18.7.4 - 2019-10-23
+
 ### Fixed
 
 - Fixed binddata not recording date picker changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed multiple `linzTimezoneOffset` attributes.
 - Fixed incorrect datepicker dates across multiple timezones.
 - Fixed ckeditor double escaping values.
+- Fixed a XSS vulnerability with the `checkboxesWithAddition` widget.
 
 ## v1.0.0-18.7.3 - 2019-10-16
 

--- a/lib/formtools/widgets/checkboxesWithAddition.js
+++ b/lib/formtools/widgets/checkboxesWithAddition.js
@@ -1,5 +1,7 @@
+'use strict';
 
-var formist = require('formist');
+const formist = require('formist');
+const linz = require('../../../');
 
 module.exports = function (attrs) {
 
@@ -48,7 +50,7 @@ module.exports = function (attrs) {
 
             if (typeof f === 'string') {
                 f = {
-                    label: f,
+                    label: linz.api.util.escape(f),
                     value: f
                 };
             }

--- a/lib/formtools/widgets/ckeditor.js
+++ b/lib/formtools/widgets/ckeditor.js
@@ -2,18 +2,6 @@
 var formist = require('formist'),
     utils = require('../../utils');
 
-var toEscape = {
-        '<': '&lt;',
-        '>': '&gt;' };
-
-var escape = function (value) {
-
-    return String(value || '').replace(/[<>]/g, function (char) {
-        return toEscape[char];
-    });
-
-};
-
 module.exports = function (attrs) {
 
     function ckeditorWidget (name, field, value) {
@@ -69,7 +57,7 @@ module.exports = function (attrs) {
 
         // add the value if there is one
         if (value !== undefined && value !== null) {
-            o.attributes.value = escape(value);
+            o.attributes.value = value;
         }
 
         // allow override on any attributes, through the attr argument

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "linz",
-    "version": "1.0.0-18.7.3",
+    "version": "1.0.0-18.7.4",
     "description": "Node.js web application framework",
     "license": "MIT",
     "main": "linz.js",


### PR DESCRIPTION
This PR fixes ckeditor double escaping content.

**Verification**

- [x] On master, edit a `Test` record.
- [x] Click on source and add something with tags in the content eg`<p>test</p>`.
- [x] Save and view the edit screen again, the p tags should incorrectly be in the content.

**Testing**

- [x] Pull in this PR and repeat the verification steps, make sure the p tag is no longer escaped.
- [x] View the XSS test record, nothing should pop up.
