### PR TITLE
Fix export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.0-18.7.5 - 2019-12-09
+
 ### Fixed
 
 - Fixed exports with a space in the name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed exports with a space in the name.
+
 ## v1.0.0-18.7.4 - 2019-10-23
 
 ### Fixed

--- a/lib/api/util/file-export.js
+++ b/lib/api/util/file-export.js
@@ -31,7 +31,7 @@ const generateExport = (opts) => {
         throw new Error('stream is a required property');
     }
 
-    options.res.setHeader('Content-disposition', `attachment; filename=${options.name}.${options.extension}`);
+    options.res.setHeader('Content-disposition', `attachment; filename="${options.name}.${options.extension}"`);
 
     if (options.contentType) {
         options.res.setHeader('Content-Type', options.contentType);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "linz",
-    "version": "1.0.0-18.7.4",
+    "version": "1.0.0-18.7.5",
     "description": "Node.js web application framework",
     "license": "MIT",
     "main": "linz.js",


### PR DESCRIPTION
I accidentally pushed this to master already, but this was the only change besides the changelog:
https://github.com/linzjs/linz/commit/181b9b59b4c8c30d3dbed58fc9f44865ed773897

## Verification

- [x] On master, change the `mtUser` model label to something with a space e.g. `label: 'User Test',`.
- [x] Try the export, your browser should try and download a file `User` that is not a csv.

## Testing

- [x] Pull in this PR and repeat the above test, it should have the proper file name now.