### PR TITLE
fix export order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v1.0.0-18.8.1 - 2020-10-13
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   Fixed default exports not appearing in the selected order.
+
 ## v1.0.0-18.8.0 - 2020-06-09
 
 ### Added

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -193,7 +193,16 @@ module.exports = {
                 const includedFields = exportObj.inclusions.length > 0 ? exportObj.inclusions.split(',') : getInclusionsFromExclusions(exportObj, Model);
                 const bodyFields = req.body.selectedFields.split(',');
                 const refFieldNames = [];
-                const fields = includedFields.filter((field) => bodyFields.includes(field))
+                const fields = [];
+
+                // Maintain selected field order.
+                bodyFields.forEach((field) => {
+                    const index = includedFields.indexOf(field);
+
+                    if (index >= 0) {
+                        fields.push(includedFields[index]);
+                    }
+                });
 
                 let filterFieldNames = [];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "linz",
-    "version": "1.0.0-18.8.0",
+    "version": "1.0.0-18.8.1",
     "description": "Node.js web application framework",
     "license": "MIT",
     "main": "linz.js",


### PR DESCRIPTION
This PR fixes the default export not appearing in the same order as selected.

**Setup**

- [x] Map in this PR.

**Testing**

- [x] For any model, use the default export and change the order of the fields.
- [x] Make sure the exported file contains columns in the same order as selected.
